### PR TITLE
Use button links

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -55,12 +55,7 @@ export async function getCheckSummaries(): Promise<Record<Severity, CheckSummary
         const persistedStep = checkSummary[severity].checks[checkType].steps[failure.stepID];
         persistedCheck.issueCount++;
         persistedStep.issueCount++;
-        persistedStep.issues.push({
-          severity,
-          reason: failure.reason,
-          action: failure.action,
-          itemID: failure.itemID,
-        });
+        persistedStep.issues.push(failure);
       }
     }
   }

--- a/src/components/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown.tsx
@@ -109,7 +109,6 @@ const getStyles = (severity: Severity) => (theme: GrafanaTheme2) => {
 
 const getIcon = (message: string) => {
   message = message.toLowerCase();
-  console.log('message', message);
   let icon: IconName = 'info-circle';
   if (message.includes('fix')) {
     icon = 'wrench';

--- a/src/components/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { css } from '@emotion/css';
-import { Button, ButtonVariant, useStyles2 } from '@grafana/ui';
+import { Button, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, IconName } from '@grafana/data';
 import { Severity, type CheckSummary as CheckSummaryType } from 'types';
-import { useNavigate } from 'react-router-dom';
 
 export default function CheckDrillDown({ checkSummary }: { checkSummary: CheckSummaryType }) {
   const styles = useStyles2(getStyles(checkSummary.severity));
-  const navigate = useNavigate();
 
   return (
     <div className={styles.container}>
@@ -33,26 +31,17 @@ export default function CheckDrillDown({ checkSummary }: { checkSummary: CheckSu
                 <div className={styles.issueReason}>
                   {issue.item}
                   {issue.links.map((link) => {
-                    const b = (
-                      <Button
-                        className={styles.issueLink}
-                        key={link.url}
-                        onClick={() => (link.url.startsWith('http') ? null : navigate(link.url))}
-                        size="sm"
-                        icon={getIcon(link.message)}
-                        variant={getVariant(link.message)}
-                      >
-                        {link.message}
-                      </Button>
+                    const extraProps = link.url.startsWith('http')
+                      ? { target: '_self', rel: 'noopener noreferrer' }
+                      : {};
+
+                    return (
+                      <a key={link.url} href={link.url} {...extraProps}>
+                        <Button size="sm" className={styles.issueLink} icon={getIcon(link.message)} variant="secondary">
+                          {link.message}
+                        </Button>
+                      </a>
                     );
-                    if (link.url.startsWith('http')) {
-                      return (
-                        <a key={link.url} href={link.url} target="_blank" rel="noopener noreferrer">
-                          {b}
-                        </a>
-                      );
-                    }
-                    return b;
                   })}
                 </div>
               </div>
@@ -122,17 +111,4 @@ const getIcon = (message: string) => {
     icon = 'cog';
   }
   return icon;
-};
-
-const getVariant = (message: string) => {
-  message = message.toLowerCase();
-  let variant: ButtonVariant = 'secondary';
-  if (message.includes('fix') || message.includes('upgrade')) {
-    variant = 'primary';
-  } else if (message.includes('info')) {
-    variant = 'secondary';
-  } else if (message.includes('delete')) {
-    variant = 'destructive';
-  }
-  return variant;
 };

--- a/src/generated/check/v0alpha1/types.status.gen.ts
+++ b/src/generated/check/v0alpha1/types.status.gen.ts
@@ -1,24 +1,37 @@
 // Code generated - EDITING IS FUTILE. DO NOT EDIT.
 
+export interface ErrorLink {
+	// URL to a page with more information about the error
+	url: string;
+	// Human readable error message
+	message: string;
+	// Icon to display next to the error message
+	icon?: string;
+	// Variant of the button that will render the link
+	variant?: "primary" | "secondary" | "destructive" | "success";
+}
+
+export const defaultErrorLink = (): ErrorLink => ({
+	url: "",
+	message: "",
+});
+
 export interface ReportFailure {
 	// Severity of the failure
 	severity: "high" | "low";
-	// Human readable reason for the failure
-	reason: string;
-	// Action to take to resolve the failure
-	action: string;
 	// Step ID that the failure is associated with
 	stepID: string;
-	// Item ID that the failure is associated with
-	itemID: string;
+	// Human readable identifier of the item that failed
+	item: string;
+	// Links to actions that can be taken to resolve the failure
+	links: ErrorLink[];
 }
 
 export const defaultReportFailure = (): ReportFailure => ({
 	severity: "high",
-	reason: "",
-	action: "",
 	stepID: "",
-	itemID: "",
+	item: "",
+	links: [],
 });
 
 export interface OperatorState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 // Types used by the frontend part of the Grafana Advisor.
 // (These are on purpose structured a bit differently than the backend generated ones.)
 
+import { ReportFailure } from 'generated/check/v0alpha1/types.status.gen';
+
 export enum Severity {
   High = 'high',
   Low = 'low',
@@ -29,12 +31,5 @@ export type CheckStep = {
   description: string;
   stepID: string;
   issueCount: number;
-  issues: CheckStepIssue[];
-};
-
-export type CheckStepIssue = {
-  severity: Severity;
-  reason: string;
-  action: string;
-  itemID: string;
+  issues: ReportFailure[];
 };


### PR DESCRIPTION
Rather than showing always the same text, refactor the action text for a button (the style may need some help here :P):

Requires https://github.com/grafana/grafana/pull/100874

Before:
<img width="892" alt="Screenshot 2025-02-18 at 14 21 49" src="https://github.com/user-attachments/assets/2dbb128d-b262-4655-9c75-68c998865563" />

After:

<img width="762" alt="Screenshot 2025-02-19 at 12 57 58" src="https://github.com/user-attachments/assets/4eaf458b-5f5b-4dbd-b409-6783851410fe" />

Fixes https://github.com/grafana/grafana-community-team/issues/351