### PR TITLE
Add page when missing the feature flag

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { AppRootProps } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import FeatureFlagMissing from 'pages/FeatureFlagMissing';
 const Home = React.lazy(() => import('../../pages/Home'));
 
 export default function App(props: AppRootProps) {
+  let component = <Home />;
+  // TODO: Remove this once the feature flag is enabled by default
+  if (!(config.featureToggles as any)['grafanaAdvisor']) {
+    component = <FeatureFlagMissing />;
+  }
   return (
     <Routes>
-      <Route path="*" element={<Home />} />
+      <Route path="*" element={component} />
     </Routes>
   );
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -6,14 +6,13 @@ import FeatureFlagMissing from 'pages/FeatureFlagMissing';
 const Home = React.lazy(() => import('../../pages/Home'));
 
 export default function App(props: AppRootProps) {
-  let component = <Home />;
   // TODO: Remove this once the feature flag is enabled by default
   if (!(config.featureToggles as any)['grafanaAdvisor']) {
-    component = <FeatureFlagMissing />;
+    return <FeatureFlagMissing />;
   }
   return (
     <Routes>
-      <Route path="*" element={component} />
+      <Route path="*" element={<Home />} />
     </Routes>
   );
 }

--- a/src/pages/FeatureFlagMissing.tsx
+++ b/src/pages/FeatureFlagMissing.tsx
@@ -1,0 +1,29 @@
+import { EmptyState, Text, TextLink } from '@grafana/ui';
+import React from 'react';
+
+export default function FeatureFlagMissing() {
+  return (
+    <EmptyState variant="call-to-action" message="Missing feature flag.">
+      <p>
+        The Grafana Advisor requires the <code>grafanaAdvisor</code> feature toggle to be enabled.
+      </p>
+      <p>
+        <TextLink
+          href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/"
+          external
+        >
+          Instructions to enable the feature toggle:
+        </TextLink>
+      </p>
+      <Text textAlignment="left">
+        <pre>
+          <code>
+            [feature_toggles]
+            <br />
+            grafanaAdvisor = true
+          </code>
+        </pre>
+      </Text>
+    </EmptyState>
+  );
+}


### PR DESCRIPTION
Handles the case in which the app is installed and enabled but the feature flag is not.

Before:
<img width="1105" alt="Screenshot 2025-03-04 at 09 57 42" src="https://github.com/user-attachments/assets/0ceafe43-90b7-4e49-a5f6-5b9703e973cb" />

After:
<img width="1106" alt="Screenshot 2025-03-04 at 09 58 17" src="https://github.com/user-attachments/assets/63b801f4-d23d-4e08-97d6-171db557ba19" />
