### PR TITLE
Auto enable app

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,6 +3,7 @@
   "type": "app",
   "name": "Grafana Advisor",
   "id": "grafana-advisor-app",
+  "autoEnabled": true,
   "info": {
     "keywords": ["app"],
     "description": "",


### PR DESCRIPTION
Any reason not to? To avoid people having to manually enable the app.