### PR TITLE
Use creationTimestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",

--- a/src/components/CheckSummary.test.tsx
+++ b/src/components/CheckSummary.test.tsx
@@ -8,7 +8,7 @@ export function getMockCheckSummary(): CheckSummaryType {
   return {
     name: 'Test Check',
     description: 'Test description',
-    updated: new Date('2023-01-01'),
+    created: new Date('2023-01-01'),
     severity: Severity.High,
     checks: {
       testCheck: {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -49,7 +49,7 @@ export default function Home() {
     createChecksState.loading ||
     deleteChecksState.loading ||
     checkSummariesState.loading;
-  const emptyState = checkSummariesState.value?.high.updated.getTime() === 0;
+  const emptyState = checkSummariesState.value?.high.created.getTime() === 0;
   const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
   const isHealthy = !isLoading && !emptyState && issueCount === 0;
 
@@ -103,7 +103,7 @@ export default function Home() {
           {!emptyState && (
             <div className={styles.headerRightColumn}>
               Last checked:{' '}
-              <strong>{checkSummariesState.value ? formatDate(checkSummariesState.value?.high.updated) : '...'}</strong>
+              <strong>{checkSummariesState.value ? formatDate(checkSummariesState.value?.high.created) : '...'}</strong>
             </div>
           )}
         </Stack>

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export type CheckSummary = {
   description: string;
   severity: Severity;
   checks: Record<string, Check>;
-  updated: Date;
+  created: Date;
 };
 
 // A check is a group of related validation steps (e.g. for datasources or plugins)


### PR DESCRIPTION
As a side effect of https://github.com/grafana/grafana/pull/102120 (I believe), the API resources are no longer annotated with the `update` timestamp since they are generated from the empty resource.

As an alternative, I've modified the app to read the `creationTimestamp`, which is always present and rely on the status annotation to verify if a check has been updated.