### PR TITLE
Add margin to link buttons

### DIFF
--- a/src/components/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown.tsx
@@ -89,6 +89,7 @@ const getStyles = (severity: Severity) => (theme: GrafanaTheme2) => {
     }),
     issueLink: css({
       float: 'right',
+      marginLeft: theme.spacing(1),
     }),
     bold: css({
       fontWeight: theme.typography.fontWeightBold,


### PR DESCRIPTION
Useful if there are more than one:

Before:
<img width="875" alt="Screenshot 2025-04-01 at 16 17 54" src="https://github.com/user-attachments/assets/51256876-f000-4675-92a3-4f735ea2f2b2" />

After:
<img width="1088" alt="Screenshot 2025-04-01 at 16 32 06" src="https://github.com/user-attachments/assets/75a2e96a-e4ef-44c4-ab2a-04caa0e98421" />
