### PR TITLE
Home page: refactor and tests

### DIFF
--- a/src/components/Actions.test.tsx
+++ b/src/components/Actions.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Actions from './Actions';
+import * as api from 'api/api';
+import { CheckSummaries } from 'types';
+
+jest.mock('api/api');
+
+const mockApi = api as jest.Mocked<typeof api>;
+
+describe('Actions', () => {
+  const user = userEvent.setup();
+  const mockCheckSummaries = jest.fn().mockResolvedValue({});
+  const defaultProps = {
+    checkSummaries: mockCheckSummaries,
+    checkSummariesState: {
+      loading: false,
+      value: {
+        high: {
+          created: new Date('2023-01-01'),
+          checks: {},
+        },
+        low: {
+          created: new Date('2023-01-01'),
+          checks: {},
+        },
+      } as CheckSummaries,
+    },
+    emptyState: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApi.createChecks.mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      ok: true,
+      headers: {} as any,
+      redirected: false,
+      type: 'basic',
+      url: '',
+      config: { url: '' },
+      data: {
+        kind: 'Check',
+        apiVersion: 'v0alpha1',
+        metadata: { name: 'test-check', namespace: 'default' },
+        spec: {},
+        status: { report: { count: 0, failures: [] } },
+      },
+    });
+    mockApi.deleteChecks.mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      ok: true,
+      headers: {} as any,
+      redirected: false,
+      type: 'basic',
+      url: '',
+      config: { url: '' },
+      data: undefined,
+    });
+
+    mockApi.waitForChecks.mockResolvedValue({
+      promise: Promise.resolve(),
+      cancel: jest.fn(),
+    });
+  });
+
+  it('renders refresh and delete buttons', async () => {
+    render(<Actions {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '' })).toBeInTheDocument(); // Delete button has no text
+    });
+  });
+
+  it('shows loading state when running checks', async () => {
+    render(
+      <Actions
+        {...defaultProps}
+        checkSummariesState={{
+          ...defaultProps.checkSummariesState,
+          loading: true,
+        }}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Running checks...')).toBeInTheDocument();
+    });
+  });
+
+  it('shows last checked time when not in empty state', async () => {
+    render(<Actions {...defaultProps} />);
+    await waitFor(() => {
+      expect(screen.getByText(/last checked:/i)).toBeInTheDocument();
+      expect(screen.getByText('2023. 01. 01. 00:00')).toBeInTheDocument();
+    });
+  });
+
+  it('hides last checked time in empty state', async () => {
+    render(<Actions {...defaultProps} emptyState={true} />);
+    await waitFor(() => {
+      expect(screen.queryByText(/last checked:/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when check creation fails', async () => {
+    const error = {
+      data: {},
+      status: 500,
+      statusText: 'Internal Server Error',
+    };
+    mockApi.createChecks.mockRejectedValue(error);
+
+    render(<Actions {...defaultProps} />);
+
+    // Wait for the refresh button to be rendered
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+    });
+
+    const refreshButton = screen.getByRole('button', { name: /refresh/i });
+    await user.click(refreshButton);
+
+    // Wait for the error state to be updated and rendered
+    await waitFor(() => {
+      expect(screen.getByText(/error while running checks: 500 internal server error/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows confirmation modal when delete button clicked', async () => {
+    render(<Actions {...defaultProps} />);
+    const deleteButton = screen.getByRole('button', { name: '' });
+    await user.click(deleteButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /delete reports\?/i })).toBeInTheDocument();
+      expect(screen.getByText(/grafana keeps a history of reports/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls delete API when deletion confirmed', async () => {
+    render(<Actions {...defaultProps} />);
+    const deleteButton = screen.getByRole('button', { name: '' });
+    await user.click(deleteButton);
+
+    const confirmButton = screen.getByRole('button', { name: /confirm/i });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockApi.deleteChecks).toHaveBeenCalled();
+    });
+  });
+
+  it('shows error message when delete API fails', async () => {
+    mockApi.deleteChecks.mockRejectedValue({
+      data: {},
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    render(<Actions {...defaultProps} />);
+    const deleteButton = screen.getByRole('button', { name: '' });
+    await user.click(deleteButton);
+
+    const confirmButton = screen.getByRole('button', { name: /confirm/i });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/error deleting checks: 500 internal server error/i)).toBeInTheDocument();
+    });
+  });
+
+  it('cancels waiting for checks when unmounting', async () => {
+    // make waitForChecks not resolve
+    const cancel = jest.fn();
+    mockApi.waitForChecks.mockImplementation(() =>
+      Promise.resolve({
+        promise: new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({});
+          }, 1000);
+        }),
+        cancel,
+      })
+    );
+    const { unmount } = render(<Actions {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(cancel).not.toHaveBeenCalled();
+    });
+
+    unmount();
+    expect(cancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/Actions.test.tsx
+++ b/src/components/Actions.test.tsx
@@ -71,7 +71,7 @@ describe('Actions', () => {
     render(<Actions {...defaultProps} />);
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: '' })).toBeInTheDocument(); // Delete button has no text
+      expect(screen.getByRole('button', { name: /delete reports/i })).toBeInTheDocument();
     });
   });
 
@@ -131,7 +131,7 @@ describe('Actions', () => {
 
   it('shows confirmation modal when delete button clicked', async () => {
     render(<Actions {...defaultProps} />);
-    const deleteButton = screen.getByRole('button', { name: '' });
+    const deleteButton = screen.getByRole('button', { name: /delete reports/i });
     await user.click(deleteButton);
 
     await waitFor(() => {
@@ -142,7 +142,7 @@ describe('Actions', () => {
 
   it('calls delete API when deletion confirmed', async () => {
     render(<Actions {...defaultProps} />);
-    const deleteButton = screen.getByRole('button', { name: '' });
+    const deleteButton = screen.getByRole('button', { name: /delete reports/i });
     await user.click(deleteButton);
 
     const confirmButton = screen.getByRole('button', { name: /confirm/i });
@@ -161,7 +161,7 @@ describe('Actions', () => {
     });
 
     render(<Actions {...defaultProps} />);
-    const deleteButton = screen.getByRole('button', { name: '' });
+    const deleteButton = screen.getByRole('button', { name: /delete reports/i });
     await user.click(deleteButton);
 
     const confirmButton = screen.getByRole('button', { name: /confirm/i });

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -83,6 +83,7 @@ export default function Actions({
             disabled={deleteChecksState.loading}
             variant="secondary"
             icon="trash-alt"
+            aria-label="Delete reports"
           ></Button>
         </Stack>
 

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import { useAsyncFn } from 'react-use';
+import * as api from 'api/api';
+import { Button, ConfirmModal, Stack, useStyles2 } from '@grafana/ui';
+import { CheckSummaries } from 'types';
+import { AsyncState } from 'react-use/lib/useAsync';
+import { isFetchError } from '@grafana/runtime';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+import { formatDate } from 'utils';
+
+export default function Actions({
+  checkSummaries,
+  checkSummariesState,
+  emptyState,
+}: {
+  checkSummaries: () => Promise<CheckSummaries>;
+  checkSummariesState: AsyncState<CheckSummaries>;
+  emptyState: boolean;
+}) {
+  const [cancelWaitForChecks, setCancelWaitForChecks] = useState<() => void>(() => {
+    return () => {};
+  });
+  useEffect(() => {
+    return cancelWaitForChecks;
+  }, [cancelWaitForChecks]);
+
+  const [completedChecksState, getCompletedChecks] = useAsyncFn(async (names?: string[]) => {
+    const { promise, cancel } = await api.waitForChecks(names);
+    setCancelWaitForChecks(() => cancel);
+    await promise;
+    await checkSummaries();
+  }, []);
+
+  const [createChecksState, createChecks] = useAsyncFn(async () => {
+    const checks = await Promise.all([api.createChecks('datasource'), api.createChecks('plugin')]);
+    const names = checks.map((check) => check.data.metadata.name);
+    await getCompletedChecks(names);
+  }, []);
+  const [deleteChecksState, deleteChecks] = useAsyncFn(async () => {
+    try {
+      await api.deleteChecks();
+      await checkSummaries();
+    } catch (error) {
+      throw error;
+    }
+  }, []);
+  const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
+
+  useEffect(() => {
+    // Wait for new checks
+    getCompletedChecks();
+  }, [getCompletedChecks]);
+
+  const isLoading =
+    completedChecksState.loading ||
+    createChecksState.loading ||
+    deleteChecksState.loading ||
+    checkSummariesState.loading;
+  const styles = useStyles2(getStyles);
+
+  return (
+    <>
+      <Stack direction="column" alignItems="flex-end">
+        <Stack direction="row">
+          <ConfirmModal
+            isOpen={confirmDeleteModalOpen}
+            title="Delete reports?"
+            body="Grafana keeps a history of reports, this action will delete all of them. It is not reversible."
+            confirmText="Confirm"
+            onConfirm={() => {
+              deleteChecks();
+              setConfirmDeleteModalOpen(false);
+            }}
+            onDismiss={() => setConfirmDeleteModalOpen(false)}
+          />
+
+          <Button onClick={createChecks} disabled={isLoading} variant="secondary" icon={isLoading ? 'spinner' : 'sync'}>
+            {isLoading ? 'Running checks...' : 'Refresh'}
+          </Button>
+          <Button
+            onClick={() => setConfirmDeleteModalOpen(true)}
+            disabled={deleteChecksState.loading}
+            variant="secondary"
+            icon="trash-alt"
+          ></Button>
+        </Stack>
+
+        <div className={styles.rightColumn}>
+          {createChecksState.error && isFetchError(createChecksState.error) && (
+            <div className={styles.apiErrorMessage}>
+              Error while running checks: {createChecksState.error.status} {createChecksState.error.statusText}
+            </div>
+          )}
+          {deleteChecksState.error && isFetchError(deleteChecksState.error) && (
+            <div className={styles.apiErrorMessage}>
+              Error deleting checks: {deleteChecksState.error.status} {deleteChecksState.error.statusText}
+            </div>
+          )}
+          {!emptyState && (
+            <div className={styles.lastChecked}>
+              Last checked:{' '}
+              <strong>{checkSummariesState.value ? formatDate(checkSummariesState.value?.high.created) : '...'}</strong>
+            </div>
+          )}
+        </div>
+      </Stack>
+    </>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  apiErrorMessage: css({
+    marginBottom: theme.spacing(1),
+    color: theme.colors.error.text,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  rightColumn: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    minWidth: '200px',
+  }),
+  lastChecked: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+});

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -60,9 +60,9 @@ export default function Actions({
   const styles = useStyles2(getStyles);
 
   return (
-    <>
-      <Stack direction="column" alignItems="flex-end">
-        <Stack direction="row">
+    <div className={styles.actionsContainer}>
+      <Stack direction="column" alignItems="flex-end" gap={0}>
+        <Stack direction="row" gap={1}>
           <ConfirmModal
             isOpen={confirmDeleteModalOpen}
             title="Delete reports?"
@@ -105,7 +105,7 @@ export default function Actions({
           )}
         </div>
       </Stack>
-    </>
+    </div>
   );
 }
 
@@ -120,8 +120,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flexDirection: 'column',
     alignItems: 'flex-end',
     minWidth: '200px',
+    marginTop: theme.spacing(1),
   }),
   lastChecked: css({
     fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  actionsContainer: css({
+    position: 'absolute',
+    right: theme.spacing(4),
+    top: theme.spacing(3),
   }),
 });

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import Home from './Home';
 import * as api from 'api/api';
 import { CheckSummaries, Check } from 'types';
@@ -9,8 +8,6 @@ jest.mock('api/api');
 const mockApi = api as jest.Mocked<typeof api>;
 
 describe('Home', () => {
-  const user = userEvent.setup();
-
   const mockCheck = (name: string, description: string, issueCount: number): Check => ({
     name,
     description,

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Home from './Home';
+import * as api from 'api/api';
+import { CheckSummaries, Check } from 'types';
+
+jest.mock('api/api');
+const mockApi = api as jest.Mocked<typeof api>;
+
+describe('Home', () => {
+  const user = userEvent.setup();
+
+  const mockCheck = (name: string, description: string, issueCount: number): Check => ({
+    name,
+    description,
+    issueCount,
+    totalCheckCount: issueCount,
+    steps: {},
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mock for successful response
+    mockApi.getCheckSummaries.mockResolvedValue({
+      high: {
+        created: new Date('2023-01-01'),
+        name: 'High Priority',
+        description: 'High priority issues',
+        severity: 'high',
+        checks: {
+          'check-1': mockCheck('Check 1', 'First check', 1),
+          'check-2': mockCheck('Check 2', 'Second check', 2),
+        },
+      },
+      low: {
+        created: new Date('2023-01-01'),
+        name: 'Low Priority',
+        description: 'Low priority issues',
+        severity: 'low',
+        checks: {
+          'check-3': mockCheck('Check 3', 'Third check', 1),
+        },
+      },
+    } as CheckSummaries);
+  });
+
+  it('shows loading state initially', async () => {
+    render(<Home />);
+    await waitFor(() => {
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when API fails', async () => {
+    const error = {
+      data: {},
+      status: 500,
+      statusText: 'Internal Server Error',
+    };
+    mockApi.getCheckSummaries.mockRejectedValue(error);
+
+    render(<Home />);
+    await waitFor(() => {
+      expect(screen.getByText(/error: 500 internal server error/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no reports exist', async () => {
+    mockApi.getCheckSummaries.mockResolvedValue({
+      high: {
+        created: new Date(0),
+        name: 'High Priority',
+        description: 'High priority issues',
+        severity: 'high',
+        checks: {},
+      },
+      low: {
+        created: new Date(0),
+        name: 'Low Priority',
+        description: 'Low priority issues',
+        severity: 'low',
+        checks: {},
+      },
+    } as CheckSummaries);
+
+    render(<Home />);
+    await waitFor(() => {
+      expect(screen.getByText(/no report found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows completed state when no issues found', async () => {
+    mockApi.getCheckSummaries.mockResolvedValue({
+      high: {
+        created: new Date('2023-01-01'),
+        name: 'High Priority',
+        description: 'High priority issues',
+        severity: 'high',
+        checks: {},
+      },
+      low: {
+        created: new Date('2023-01-01'),
+        name: 'Low Priority',
+        description: 'Low priority issues',
+        severity: 'low',
+        checks: {},
+      },
+    } as CheckSummaries);
+
+    render(<Home />);
+    await waitFor(() => {
+      expect(screen.getByText(/no issues found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows check summaries when issues exist', async () => {
+    render(<Home />);
+    await waitFor(() => {
+      expect(screen.getByText(/3 items needs to be fixed/i)).toBeInTheDocument();
+      expect(screen.getByText(/1 items may need your attention/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useAsyncFn } from 'react-use';
 import { css } from '@emotion/css';
-import { Button, ConfirmModal, EmptyState, LoadingPlaceholder, Stack, useStyles2 } from '@grafana/ui';
+import { EmptyState, LoadingPlaceholder, Stack, useStyles2 } from '@grafana/ui';
 import { isFetchError, PluginPage } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import * as api from 'api/api';
 import { CheckSummary } from 'components/CheckSummary';
-import { formatDate } from 'utils';
 import { MoreInfo } from 'components/MoreInfo';
+import Actions from 'components/Actions';
 
 export default function Home() {
   const styles = useStyles2(getStyles);
@@ -19,46 +19,12 @@ export default function Home() {
     setIssueCount(highIssueCount + lowIssueCount);
     return summaries;
   }, []);
-  const [deleteChecksState, deleteChecks] = useAsyncFn(async () => {
-    try {
-      await api.deleteChecks();
-      await checkSummaries();
-    } catch (error) {
-      throw error;
-    }
-  }, []);
-  const [cancelWaitForChecks, setCancelWaitForChecks] = useState<() => void>(() => {
-    return () => {};
-  });
-  useEffect(() => {
-    return cancelWaitForChecks;
-  }, [cancelWaitForChecks]);
-  const [completedChecksState, getCompletedChecks] = useAsyncFn(async (names?: string[]) => {
-    const { promise, cancel } = await api.waitForChecks(names);
-    setCancelWaitForChecks(() => cancel);
-    await promise;
-    await checkSummaries();
-  }, []);
-  const [createChecksState, createChecks] = useAsyncFn(async () => {
-    try {
-      const checks = await Promise.all([api.createChecks('datasource'), api.createChecks('plugin')]);
-      const names = checks.map((check) => check.data.metadata.name);
-      await getCompletedChecks(names);
-    } catch (error) {
-      throw error;
-    }
-  }, []);
   useEffect(() => {
     checkSummaries();
-    getCompletedChecks();
-  }, [checkSummaries, getCompletedChecks]);
-  const isLoading =
-    completedChecksState.loading ||
-    createChecksState.loading ||
-    deleteChecksState.loading ||
-    checkSummariesState.loading;
+  }, [checkSummaries]);
+
+  const isLoading = checkSummariesState.loading;
   const emptyState = checkSummariesState.value?.high.created.getTime() === 0;
-  const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
   const isHealthy = !isLoading && !emptyState && !checkSummariesState.error && issueCount === 0;
 
   return (
@@ -68,54 +34,10 @@ export default function Home() {
         subTitle: 'Keep Grafana running smoothly and securely',
       }}
       actions={
-        <>
-          <Button onClick={createChecks} disabled={isLoading} variant="secondary" icon={isLoading ? 'spinner' : 'sync'}>
-            {isLoading ? 'Running checks...' : 'Refresh'}
-          </Button>
-          <Button
-            onClick={() => setConfirmDeleteModalOpen(true)}
-            disabled={deleteChecksState.loading}
-            variant="secondary"
-            icon="trash-alt"
-          ></Button>
-        </>
+        <Actions checkSummaries={checkSummaries} checkSummariesState={checkSummariesState} emptyState={emptyState} />
       }
     >
-      <ConfirmModal
-        isOpen={confirmDeleteModalOpen}
-        title="Delete reports?"
-        body="Grafana keeps a history of reports, this action will delete all of them. It is not reversible."
-        confirmText="Confirm"
-        onConfirm={() => {
-          deleteChecks();
-          setConfirmDeleteModalOpen(false);
-        }}
-        onDismiss={() => setConfirmDeleteModalOpen(false)}
-      />
-
       <div className={styles.page}>
-        {/* Header */}
-        <Stack direction="row">
-          <div className={styles.headerLeftColumn}>
-            {createChecksState.error && isFetchError(createChecksState.error) && (
-              <div className={styles.apiErrorMessage}>
-                Error while running checks: {createChecksState.error.status} {createChecksState.error.statusText}
-              </div>
-            )}
-            {deleteChecksState.error && isFetchError(deleteChecksState.error) && (
-              <div className={styles.apiErrorMessage}>
-                Error deleting checks: {deleteChecksState.error.status} {deleteChecksState.error.statusText}
-              </div>
-            )}
-          </div>
-          {!emptyState && (
-            <div className={styles.headerRightColumn}>
-              Last checked:{' '}
-              <strong>{checkSummariesState.value ? formatDate(checkSummariesState.value?.high.created) : '...'}</strong>
-            </div>
-          )}
-        </Stack>
-
         {/* Loading */}
         {checkSummariesState.loading && (
           <div className={styles.loading}>
@@ -132,11 +54,7 @@ export default function Home() {
 
         {/* Empty state */}
         {!checkSummariesState.loading && !checkSummariesState.error && emptyState && (
-          <EmptyState variant="not-found" message="No report found.">
-            <Button onClick={createChecks} disabled={isLoading} variant="primary">
-              Run analysis
-            </Button>
-          </EmptyState>
+          <EmptyState variant="not-found" message="No report found. Click the Refresh button to run analysis." />
         )}
 
         {/* All issues resolved */}
@@ -164,28 +82,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   page: css({
     maxWidth: theme.breakpoints.values.xxl,
   }),
-  checkSummaryLink: css({
-    flex: 1,
-  }),
   checksSummaries: css({
     marginTop: theme.spacing(2),
-  }),
-  apiErrorMessage: css({
-    marginTop: theme.spacing(2),
-    color: theme.colors.error.text,
-    fontSize: theme.typography.bodySmall.fontSize,
   }),
   loading: css({
     marginTop: theme.spacing(2),
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-  }),
-  headerLeftColumn: css({
-    flexGrow: 1,
-  }),
-  headerRightColumn: css({
-    fontSize: theme.typography.bodySmall.fontSize,
-    width: '200px',
   }),
 });


### PR DESCRIPTION
Move all the actions related code to its own component and write unit tests for both the new Actions component and for what's left in the Home page.

There is a sligh change in style, but the rest remains the same.

Before:
<img width="1212" alt="Screenshot 2025-04-03 at 13 25 49" src="https://github.com/user-attachments/assets/07d41115-6bbd-448a-923e-f0d84c3cbf2a" />

After:
<img width="983" alt="Screenshot 2025-04-03 at 13 36 48" src="https://github.com/user-attachments/assets/08ba893e-bf84-4d44-8de6-b9ddfee0c3f9" />
