### PR TITLE
CI: Update bundle-stats to run on pushes to main

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
The bundle-stats workflow has been updated to generate build artefacts from main. Updating the workflow so it triggers on pushes to main. 🤞 

_Note: this won't actually fix the runs until it's merged._