### PR TITLE
UX improvements

### DIFF
--- a/src/components/CheckDrillDown.test.tsx
+++ b/src/components/CheckDrillDown.test.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import CheckDrillDown from './CheckDrillDown';
 import { CheckSummaries, Severity } from 'types';
 import { getEmptyCheckSummary, getEmptyCheckTypes } from 'api/api';
+import { renderWithRouter } from '../pages/Home.test';
 
 describe('Components/CheckDrillDown', () => {
   let checkSummaries: CheckSummaries;
 
   beforeEach(() => {
+    Element.prototype.scrollIntoView = jest.fn();
     checkSummaries = getEmptyCheckSummary(getEmptyCheckTypes());
 
     // Datasources
@@ -24,33 +27,62 @@ describe('Components/CheckDrillDown', () => {
     // Plugins
     checkSummaries.high.checks.plugin.issueCount = 0;
     checkSummaries.high.checks.plugin.steps.step1.issues = [];
+  });
 
-    render(<CheckDrillDown checkSummary={checkSummaries.high} />);
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   test('should not display a check that has no issues', async () => {
+    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
     expect(screen.queryByText(/Step 1 failed for 1 plugin/im)).not.toBeInTheDocument();
   });
 
   test('should display a summary of the failing steps', async () => {
-    expect(await screen.findByText(/Step 1 failed for 1 datasource/im)).toBeInTheDocument();
+    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    expect(await screen.findByText(/Step 1 failed/im)).toBeInTheDocument();
   });
 
   test('should display a the resolution of a step', async () => {
+    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
     expect(await screen.findByText(checkSummaries.high.checks.datasource.steps.step1.resolution)).toBeInTheDocument();
   });
 
   test('should display the failing items under the step', async () => {
+    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    // Click on the step
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/Step 1 failed/i));
     expect(
       await screen.findByText(checkSummaries.high.checks.datasource.steps.step1.issues[0].item)
     ).toBeInTheDocument();
   });
 
   test('should display a button if the step issue has a link', async () => {
+    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    // Click on the step
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/Step 1 failed/i));
     expect(
       await screen.findByRole('button', {
         name: checkSummaries.high.checks.datasource.steps.step1.issues[0].links[0].message,
       })
     ).toBeInTheDocument();
+  });
+
+  test('should open the test section and scroll to the step when the url has a scrollToStep param', async () => {
+    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />, {
+      route: '/?openSteps=step1&scrollToStep=Item%201',
+    });
+
+    // Verify scrollIntoView has been called
+    expect(
+      await screen.findByRole('button', {
+        name: checkSummaries.high.checks.datasource.steps.step1.issues[0].links[0].message,
+      })
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/CheckDrillDown.test.tsx
+++ b/src/components/CheckDrillDown.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CheckDrillDown from './CheckDrillDown';
 import { CheckSummaries, Severity } from 'types';
@@ -75,12 +75,12 @@ describe('Components/CheckDrillDown', () => {
       route: '/?openSteps=step1&scrollToStep=Item%201',
     });
 
-    // Verify scrollIntoView has been called
     expect(
       await screen.findByRole('button', {
         name: checkSummaries.high.checks.datasource.steps.step1.issues[0].links[0].message,
       })
     ).toBeInTheDocument();
+    // Verify scrollIntoView has been called
     await waitFor(() => {
       expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
     });

--- a/src/components/CheckDrillDown.test.tsx
+++ b/src/components/CheckDrillDown.test.tsx
@@ -4,8 +4,7 @@ import userEvent from '@testing-library/user-event';
 import CheckDrillDown from './CheckDrillDown';
 import { CheckSummaries, Severity } from 'types';
 import { getEmptyCheckSummary, getEmptyCheckTypes } from 'api/api';
-import { renderWithRouter } from '../pages/Home.test';
-
+import { renderWithRouter } from './test/utils';
 describe('Components/CheckDrillDown', () => {
   let checkSummaries: CheckSummaries;
 

--- a/src/components/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/css';
 import { Button, Collapse, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, IconName } from '@grafana/data';
@@ -7,11 +7,11 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function CheckDrillDown({ checkSummary }: { checkSummary: CheckSummaryType }) {
   const styles = useStyles2(getStyles(checkSummary.severity));
-  const [isOpen, setIsOpen] = React.useState<Record<string, boolean>>({});
+  const [isOpen, setIsOpen] = useState<Record<string, boolean>>({});
   const location = useLocation();
   const navigate = useNavigate();
   const scrollToRef = useRef<HTMLDivElement>(null);
-  const [scrollToStep, setScrollToStep] = React.useState<string | null>(null);
+  const [scrollToStep, setScrollToStep] = useState<string | null>(null);
 
   useEffect(() => {
     // Restore state from URL

--- a/src/components/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown.tsx
@@ -61,69 +61,60 @@ export default function CheckDrillDown({ checkSummary }: { checkSummary: CheckSu
           return null;
         }
 
-        return Object.values(check.steps).map((step) => {
-          const stepIsOpen = isOpen[step.stepID] ?? false;
-          return (
-            <div key={step.stepID} className={styles.spacingTopMd} data-step-id={step.stepID}>
-              {step.issues.length > 0 && (
-                <Collapse
-                  label={
-                    <div className={styles.description}>
-                      <div>
-                        {step.name} failed for {step.issues.length} {check.name}
-                        {step.issues.length > 1 ? 's' : ''}.
-                      </div>
-                      <div className={styles.resolution} dangerouslySetInnerHTML={{ __html: step.resolution }}></div>
+        return Object.values(check.steps).map((step) => (
+          <div key={step.stepID} className={styles.spacingTopMd} data-step-id={step.stepID}>
+            {step.issues.length > 0 && (
+              <Collapse
+                label={
+                  <div className={styles.description}>
+                    <div>
+                      {step.name} failed for {step.issues.length} {check.name}
+                      {step.issues.length > 1 ? 's' : ''}.
                     </div>
-                  }
-                  isOpen={stepIsOpen}
-                  collapsible={true}
-                  onToggle={() => handleToggle(step.stepID)}
-                >
-                  {step.issues.map((issue) => {
-                    let ref = null;
-                    if (issue.item === scrollToStep) {
-                      ref = scrollToRef;
-                    }
-                    return (
-                      <div key={issue.item} className={styles.issue} ref={ref}>
-                        <div className={styles.issueReason}>
-                          {issue.item}
-                          {issue.links.map((link) => {
-                            const extraProps = link.url.startsWith('http')
-                              ? { target: '_self', rel: 'noopener noreferrer' }
-                              : {};
-                            return (
-                              <a
-                                key={link.url}
-                                href={link.url}
-                                onClick={() => {
-                                  const params = new URLSearchParams(location.search);
-                                  params.set('scrollToStep', issue.item);
-                                  navigate({ search: params.toString() }, { replace: true });
-                                }}
-                                {...extraProps}
-                              >
-                                <Button
-                                  size="sm"
-                                  className={styles.issueLink}
-                                  icon={getIcon(link.message)}
-                                  variant="secondary"
-                                >
-                                  {link.message}
-                                </Button>
-                              </a>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </Collapse>
-              )}
-            </div>
-          );
-        });
+                    <div className={styles.resolution} dangerouslySetInnerHTML={{ __html: step.resolution }}></div>
+                  </div>
+                }
+                isOpen={isOpen[step.stepID] ?? false}
+                collapsible={true}
+                onToggle={() => handleToggle(step.stepID)}
+              >
+                {step.issues.map((issue) => (
+                  <div key={issue.item} className={styles.issue} ref={issue.item === scrollToStep ? scrollToRef : null}>
+                    <div className={styles.issueReason}>
+                      {issue.item}
+                      {issue.links.map((link) => {
+                        const extraProps = link.url.startsWith('http')
+                          ? { target: '_self', rel: 'noopener noreferrer' }
+                          : {};
+                        return (
+                          <a
+                            key={link.url}
+                            href={link.url}
+                            onClick={() => {
+                              const params = new URLSearchParams(location.search);
+                              params.set('scrollToStep', issue.item);
+                              navigate({ search: params.toString() }, { replace: true });
+                            }}
+                            {...extraProps}
+                          >
+                            <Button
+                              size="sm"
+                              className={styles.issueLink}
+                              icon={getIcon(link.message)}
+                              variant="secondary"
+                            >
+                              {link.message}
+                            </Button>
+                          </a>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </Collapse>
+            )}
+          </div>
+        ));
       })}
     </div>
   );

--- a/src/components/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown.tsx
@@ -53,6 +53,12 @@ export default function CheckDrillDown({ checkSummary }: { checkSummary: CheckSu
     navigate({ search: params.toString() }, { replace: true });
   };
 
+  const handleStepClick = (item: string) => {
+    const params = new URLSearchParams(location.search);
+    params.set('scrollToStep', item);
+    navigate({ search: params.toString() }, { replace: true });
+  };
+
   return (
     <div className={styles.container}>
       {Object.values(checkSummary.checks).map((check) => {
@@ -62,7 +68,7 @@ export default function CheckDrillDown({ checkSummary }: { checkSummary: CheckSu
         }
 
         return Object.values(check.steps).map((step) => (
-          <div key={step.stepID} className={styles.spacingTopMd} data-step-id={step.stepID}>
+          <div key={step.stepID} className={styles.spacingTopMd}>
             {step.issues.length > 0 && (
               <Collapse
                 label={
@@ -87,16 +93,7 @@ export default function CheckDrillDown({ checkSummary }: { checkSummary: CheckSu
                           ? { target: '_self', rel: 'noopener noreferrer' }
                           : {};
                         return (
-                          <a
-                            key={link.url}
-                            href={link.url}
-                            onClick={() => {
-                              const params = new URLSearchParams(location.search);
-                              params.set('scrollToStep', issue.item);
-                              navigate({ search: params.toString() }, { replace: true });
-                            }}
-                            {...extraProps}
-                          >
+                          <a key={link.url} href={link.url} onClick={() => handleStepClick(issue.item)} {...extraProps}>
                             <Button
                               size="sm"
                               className={styles.issueLink}

--- a/src/components/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown.tsx
@@ -159,6 +159,12 @@ const getStyles = (severity: Severity) => (theme: GrafanaTheme2) => {
       backgroundColor: theme.colors.background.secondary,
       padding: theme.spacing(2),
       marginBottom: theme.spacing(1),
+      borderColor: 'transparent',
+      borderStyle: 'solid',
+      ':hover': {
+        borderColor: theme.colors.border.strong,
+        borderStyle: 'solid',
+      },
     }),
     issueReason: css({
       color: theme.colors.text.primary,

--- a/src/components/CheckSummary.test.tsx
+++ b/src/components/CheckSummary.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { CheckSummary } from './CheckSummary';
 import userEvent from '@testing-library/user-event';
 import { Severity, type CheckSummary as CheckSummaryType } from 'types';

--- a/src/components/CheckSummary.test.tsx
+++ b/src/components/CheckSummary.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { CheckSummary } from './CheckSummary';
 import userEvent from '@testing-library/user-event';
 import { Severity, type CheckSummary as CheckSummaryType } from 'types';
-import { renderWithRouter } from '../pages/Home.test';
+import { renderWithRouter } from './test/utils';
 
 export function getMockCheckSummary(): CheckSummaryType {
   return {

--- a/src/components/CheckSummary.test.tsx
+++ b/src/components/CheckSummary.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { CheckSummary } from './CheckSummary';
 import userEvent from '@testing-library/user-event';
 import { Severity, type CheckSummary as CheckSummaryType } from 'types';
+import { renderWithRouter } from '../pages/Home.test';
 
 export function getMockCheckSummary(): CheckSummaryType {
   return {
@@ -47,21 +48,29 @@ export function getMockCheckSummary(): CheckSummaryType {
 describe('CheckSummary', () => {
   const mockCheckSummary = getMockCheckSummary();
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders check summary title with correct count', () => {
-    render(<CheckSummary checkSummary={mockCheckSummary} />);
+    renderWithRouter(<CheckSummary checkSummary={mockCheckSummary} />);
     expect(screen.getByText(/2 items needs to be fixed/i)).toBeInTheDocument();
   });
 
   it('shows drilldown content when expanded', async () => {
     const user = userEvent.setup();
-
-    render(<CheckSummary checkSummary={mockCheckSummary} />);
+    renderWithRouter(<CheckSummary checkSummary={mockCheckSummary} />);
 
     // Click to expand
     await user.click(screen.getByText(/Test Check/i));
 
     // Check if drilldown content is visible
     expect(screen.getByText('Step 1 failed for 2 Test Check Items.')).toBeInTheDocument();
+
+    // Click to expand step 1
+    await user.click(screen.getByText(/Step 1/i));
+
+    // Check if drilldown content is visible
     expect(screen.getByText('Issue 1')).toBeInTheDocument();
     expect(screen.getByText('Issue 2')).toBeInTheDocument();
   });
@@ -83,7 +92,7 @@ describe('CheckSummary', () => {
       },
     };
 
-    const { container } = render(<CheckSummary checkSummary={noIssuesCheckSummary} />);
+    const { container } = renderWithRouter(<CheckSummary checkSummary={noIssuesCheckSummary} />);
     expect(container.firstChild).toBeNull();
   });
 });

--- a/src/components/CheckSummary.tsx
+++ b/src/components/CheckSummary.tsx
@@ -18,13 +18,14 @@ export function CheckSummary({ checkSummary }: Props) {
   const issueCount = Object.values(checkSummary.checks).reduce((acc, check) => acc + check.issueCount, 0);
   const location = useLocation();
   const navigate = useNavigate();
+  const isSummaryOpenParam = 'summaryOpen' + checkSummary.severity;
 
   useEffect(() => {
     // Restore state from URL
     const params = new URLSearchParams(location.search);
-    const isSummaryOpen = params.get('summaryOpen') === 'true';
+    const isSummaryOpen = params.get(isSummaryOpenParam) === 'true';
     setIsOpen(isSummaryOpen);
-  }, [location.search]);
+  }, [location.search, isSummaryOpenParam]);
 
   const handleToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);
@@ -32,9 +33,9 @@ export function CheckSummary({ checkSummary }: Props) {
     // Update URL with summary state
     const params = new URLSearchParams(location.search);
     if (isOpen) {
-      params.set('summaryOpen', 'true');
+      params.set(isSummaryOpenParam, 'true');
     } else {
-      params.delete('summaryOpen');
+      params.delete(isSummaryOpenParam);
     }
     navigate({ search: params.toString() }, { replace: true });
   };

--- a/src/components/CheckSummary.tsx
+++ b/src/components/CheckSummary.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Collapse } from '@grafana/ui';
 import { Severity, type CheckSummary as CheckSummaryType } from 'types';
 import { CheckSummaryTitle } from './CheckSummaryTitle';
 import CheckDrillDown from './CheckDrillDown';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface Props {
   checkSummary: CheckSummaryType;
@@ -15,6 +16,28 @@ export function CheckSummary({ checkSummary }: Props) {
   const [isOpen, setIsOpen] = React.useState(false);
   const styles = useStyles2(getStyles(checkSummary.severity));
   const issueCount = Object.values(checkSummary.checks).reduce((acc, check) => acc + check.issueCount, 0);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Restore state from URL
+    const params = new URLSearchParams(location.search);
+    const isSummaryOpen = params.get('summaryOpen') === 'true';
+    setIsOpen(isSummaryOpen);
+  }, [location.search]);
+
+  const handleToggle = (isOpen: boolean) => {
+    setIsOpen(isOpen);
+
+    // Update URL with summary state
+    const params = new URLSearchParams(location.search);
+    if (isOpen) {
+      params.set('summaryOpen', 'true');
+    } else {
+      params.delete('summaryOpen');
+    }
+    navigate({ search: params.toString() }, { replace: true });
+  };
 
   if (issueCount === 0) {
     return null;
@@ -25,7 +48,7 @@ export function CheckSummary({ checkSummary }: Props) {
       label={<CheckSummaryTitle checkSummary={checkSummary} />}
       isOpen={isOpen}
       collapsible={true}
-      onToggle={() => setIsOpen(!isOpen)}
+      onToggle={() => handleToggle(!isOpen)}
     >
       {/* Issues */}
       <div className={styles.issues}>

--- a/src/components/test/utils.tsx
+++ b/src/components/test/utils.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+// Helper function to render with router
+export const renderWithRouter = (ui: React.ReactElement, { route = '/' } = {}) => {
+  return render(
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }} initialEntries={[route]}>
+      {ui}
+    </MemoryRouter>
+  );
+};

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import Home from './Home';
 import { CheckSummaries, Severity } from 'types';
-import { MemoryRouter } from 'react-router-dom';
-
-// Helper function to render with router
-export const renderWithRouter = (ui: React.ReactElement, { route = '/' } = {}) => {
-  return render(
-    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }} initialEntries={[route]}>
-      {ui}
-    </MemoryRouter>
-  );
-};
+import { renderWithRouter } from 'components/test/utils';
 
 // Mock PluginPage to render its actions prop
 jest.mock('@grafana/runtime', () => ({

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -2,6 +2,16 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import Home from './Home';
 import { CheckSummaries, Severity } from 'types';
+import { MemoryRouter } from 'react-router-dom';
+
+// Helper function to render with router
+export const renderWithRouter = (ui: React.ReactElement, { route = '/' } = {}) => {
+  return render(
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }} initialEntries={[route]}>
+      {ui}
+    </MemoryRouter>
+  );
+};
 
 // Mock PluginPage to render its actions prop
 jest.mock('@grafana/runtime', () => ({
@@ -98,7 +108,7 @@ describe('Home', () => {
       error,
     });
 
-    render(<Home />);
+    renderWithRouter(<Home />);
     expect(await screen.findByText(/Error: 500 Internal Server Error/)).toBeInTheDocument();
   });
 
@@ -125,7 +135,7 @@ describe('Home', () => {
       error: undefined,
     });
 
-    render(<Home />);
+    renderWithRouter(<Home />);
     expect(await screen.findByText(/No report found/)).toBeInTheDocument();
   });
 
@@ -154,12 +164,12 @@ describe('Home', () => {
       error: undefined,
     });
 
-    render(<Home />);
+    renderWithRouter(<Home />);
     expect(await screen.findByText(/No issues found/)).toBeInTheDocument();
   });
 
   it('shows check summaries when issues exist', async () => {
-    render(<Home />);
+    renderWithRouter(<Home />);
     await waitFor(() => {
       expect(screen.getByText(/3 items needs to be fixed/i)).toBeInTheDocument();
       expect(screen.getByText(/1 items may need your attention/i)).toBeInTheDocument();
@@ -167,7 +177,7 @@ describe('Home', () => {
   });
 
   it('shows last checked time when not in empty state', async () => {
-    render(<Home />);
+    renderWithRouter(<Home />);
     await waitFor(() => {
       expect(screen.getByText(/last checked:/i)).toBeInTheDocument();
       expect(screen.getByText('2023. 01. 01. 00:00')).toBeInTheDocument();
@@ -197,7 +207,7 @@ describe('Home', () => {
       error: undefined,
     });
 
-    render(<Home />);
+    renderWithRouter(<Home />);
     await waitFor(() => {
       expect(screen.queryByText(/last checked:/i)).not.toBeInTheDocument();
     });


### PR DESCRIPTION
Fix 3 out of 4 UX issues from https://github.com/grafana/grafana-community-team/issues/366:

 - Adds a collapse button per check step. This prevents from having a step with too many issues that buries other steps.
 - Keep the state in the URL. Store opened sections and the element clicked so when navigating back, the same sections will be opened and it will automatically scroll to the previous state.
 - Adds a border when hovering over an element. Since the table may be quite wide, this helps to easily see which button belongs to which element.

Before:

https://github.com/user-attachments/assets/5c46c653-4199-4c97-ba30-4066ecc14c39

After:

https://github.com/user-attachments/assets/9b15339d-2b08-4e7e-b68a-e2dd92c390d4
