### PR TITLE
Allow to retry a single check

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,4 @@
 {
-  "extends": "./.config/.eslintrc"
+  "extends": "./.config/.eslintrc",
+  "ignorePatterns": ["src/generated/endpoints.gen.ts"]
 }

--- a/src/components/Actions.test.tsx
+++ b/src/components/Actions.test.tsx
@@ -3,12 +3,10 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Actions from './Actions';
 
-const mockUseCompletedChecks = jest.fn();
 const mockUseCreateChecks = jest.fn();
 const mockUseDeleteChecks = jest.fn();
 
 jest.mock('api/api', () => ({
-  useCompletedChecks: () => mockUseCompletedChecks(),
   useCreateChecks: () => mockUseCreateChecks(),
   useDeleteChecks: () => mockUseDeleteChecks(),
 }));
@@ -18,11 +16,6 @@ describe('Actions', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockUseCompletedChecks.mockReturnValue({
-      isCompleted: true,
-      isLoading: false,
-    });
 
     mockUseCreateChecks.mockReturnValue({
       createChecks: jest.fn(),
@@ -36,7 +29,7 @@ describe('Actions', () => {
   });
 
   it('renders refresh and delete buttons', async () => {
-    render(<Actions />);
+    render(<Actions isCompleted={true} />);
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /delete reports/i })).toBeInTheDocument();
@@ -44,12 +37,7 @@ describe('Actions', () => {
   });
 
   it('shows loading state when running checks', async () => {
-    mockUseCompletedChecks.mockReturnValue({
-      isCompleted: false,
-      isLoading: true,
-    });
-
-    render(<Actions />);
+    render(<Actions isCompleted={false} />);
     await waitFor(() => {
       expect(screen.getByText('Running checks...')).toBeInTheDocument();
     });
@@ -67,14 +55,14 @@ describe('Actions', () => {
       createCheckState: { isError: true, error },
     });
 
-    render(<Actions />);
+    render(<Actions isCompleted={true} />);
     await waitFor(() => {
       expect(screen.getByText(/error while running checks: 500 internal server error/i)).toBeInTheDocument();
     });
   });
 
   it('shows confirmation modal when delete button clicked', async () => {
-    render(<Actions />);
+    render(<Actions isCompleted={true} />);
     const deleteButton = screen.getByRole('button', { name: /delete reports/i });
     await user.click(deleteButton);
 
@@ -91,7 +79,7 @@ describe('Actions', () => {
       deleteChecksState: { isLoading: false, isError: false, error: undefined },
     });
 
-    render(<Actions />);
+    render(<Actions isCompleted={true} />);
     const deleteButton = screen.getByRole('button', { name: /delete reports/i });
     await user.click(deleteButton);
 
@@ -115,7 +103,7 @@ describe('Actions', () => {
       deleteChecksState: { isLoading: false, isError: true, error },
     });
 
-    render(<Actions />);
+    render(<Actions isCompleted={true} />);
     await waitFor(() => {
       expect(screen.getByText(/error deleting checks: 500 internal server error/i)).toBeInTheDocument();
     });
@@ -128,7 +116,7 @@ describe('Actions', () => {
       createCheckState: { isError: false, error: undefined },
     });
 
-    render(<Actions />);
+    render(<Actions isCompleted={true} />);
     const refreshButton = screen.getByRole('button', { name: /refresh/i });
     await user.click(refreshButton);
 

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -3,10 +3,9 @@ import { Button, ConfirmModal, Stack, useStyles2 } from '@grafana/ui';
 import { isFetchError } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
-import { useCompletedChecks, useDeleteChecks, useCreateChecks } from 'api/api';
+import { useDeleteChecks, useCreateChecks } from 'api/api';
 
-export default function Actions() {
-  const { isCompleted, isLoading } = useCompletedChecks();
+export default function Actions({ isCompleted }: { isCompleted: boolean }) {
   const { createChecks, createCheckState } = useCreateChecks();
   const { deleteChecks, deleteChecksState } = useDeleteChecks();
   const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
@@ -34,11 +33,11 @@ export default function Actions() {
               e.preventDefault();
               createChecks();
             }}
-            disabled={isLoading || !isCompleted}
+            disabled={!isCompleted}
             variant="secondary"
-            icon={isLoading || !isCompleted ? 'spinner' : 'sync'}
+            icon={!isCompleted ? 'spinner' : 'sync'}
           >
-            {isLoading || !isCompleted ? 'Running checks...' : 'Refresh'}
+            {isCompleted ? 'Refresh' : 'Running checks...'}
           </Button>
           <Button
             onClick={() => setConfirmDeleteModalOpen(true)}

--- a/src/components/CheckDrillDown.test.tsx
+++ b/src/components/CheckDrillDown.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import CheckDrillDown from './CheckDrillDown';
+import CheckDrillDown, { CheckDrillDownProps } from './CheckDrillDown';
 import { CheckSummaries, Severity } from 'types';
 import { getEmptyCheckSummary, getEmptyCheckTypes } from 'api/api';
 import { renderWithRouter } from './test/utils';
+
 describe('Components/CheckDrillDown', () => {
   let checkSummaries: CheckSummaries;
+  let defaultProps: CheckDrillDownProps;
 
   beforeEach(() => {
     Element.prototype.scrollIntoView = jest.fn();
@@ -14,18 +16,27 @@ describe('Components/CheckDrillDown', () => {
 
     // Datasources
     checkSummaries.high.checks.datasource.issueCount = 1;
+    checkSummaries.high.checks.datasource.canRetry = true;
+    checkSummaries.high.checks.datasource.name = 'datasource';
     checkSummaries.high.checks.datasource.steps.step1.issues = [
       {
         severity: Severity.High,
         stepID: 'step1',
         item: 'Item 1',
         links: [{ url: 'http://example.com', message: 'More info' }],
+        itemID: 'item1',
+        isRetrying: false,
       },
     ];
 
     // Plugins
     checkSummaries.high.checks.plugin.issueCount = 0;
     checkSummaries.high.checks.plugin.steps.step1.issues = [];
+    defaultProps = {
+      checkSummary: checkSummaries.high,
+      retryCheck: jest.fn(),
+      isCompleted: true,
+    };
   });
 
   afterEach(() => {
@@ -33,22 +44,22 @@ describe('Components/CheckDrillDown', () => {
   });
 
   test('should not display a check that has no issues', async () => {
-    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    renderWithRouter(<CheckDrillDown {...defaultProps} />);
     expect(screen.queryByText(/Step 1 failed for 1 plugin/im)).not.toBeInTheDocument();
   });
 
   test('should display a summary of the failing steps', async () => {
-    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    renderWithRouter(<CheckDrillDown {...defaultProps} />);
     expect(await screen.findByText(/Step 1 failed/im)).toBeInTheDocument();
   });
 
   test('should display a the resolution of a step', async () => {
-    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    renderWithRouter(<CheckDrillDown {...defaultProps} />);
     expect(await screen.findByText(checkSummaries.high.checks.datasource.steps.step1.resolution)).toBeInTheDocument();
   });
 
   test('should display the failing items under the step', async () => {
-    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    renderWithRouter(<CheckDrillDown {...defaultProps} />);
     // Click on the step
     const user = userEvent.setup();
     await user.click(screen.getByText(/Step 1 failed/i));
@@ -58,7 +69,7 @@ describe('Components/CheckDrillDown', () => {
   });
 
   test('should display a button if the step issue has a link', async () => {
-    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />);
+    renderWithRouter(<CheckDrillDown {...defaultProps} />);
     // Click on the step
     const user = userEvent.setup();
     await user.click(screen.getByText(/Step 1 failed/i));
@@ -70,7 +81,7 @@ describe('Components/CheckDrillDown', () => {
   });
 
   test('should open the test section and scroll to the step when the url has a scrollToStep param', async () => {
-    renderWithRouter(<CheckDrillDown checkSummary={checkSummaries.high} />, {
+    renderWithRouter(<CheckDrillDown {...defaultProps} />, {
       route: '/?openSteps=step1&scrollToStep=Item%201',
     });
 
@@ -83,5 +94,26 @@ describe('Components/CheckDrillDown', () => {
     await waitFor(() => {
       expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
     });
+  });
+
+  test('should display a retry button if the step issue has a retry annotation', async () => {
+    renderWithRouter(<CheckDrillDown {...defaultProps} />);
+    // Click on the step
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/Step 1 failed/i));
+    expect(screen.getByRole('button', { name: 'Retry check' })).toBeInTheDocument();
+    // Click on the retry button
+    await user.click(screen.getByRole('button', { name: 'Retry check' }));
+    expect(defaultProps.retryCheck).toHaveBeenCalledWith('datasource', 'item1');
+  });
+
+  test('should disable the retry button if the check is not completed', async () => {
+    defaultProps.isCompleted = false;
+    renderWithRouter(<CheckDrillDown {...defaultProps} />);
+    // Click on the step
+    const user = userEvent.setup();
+    await user.click(screen.getByText(/Step 1 failed/i));
+
+    expect(screen.getByRole('button', { name: 'Retry check' })).toBeDisabled();
   });
 });

--- a/src/components/CheckSummary.test.tsx
+++ b/src/components/CheckSummary.test.tsx
@@ -13,10 +13,12 @@ export function getMockCheckSummary(): CheckSummaryType {
     severity: Severity.High,
     checks: {
       testCheck: {
-        name: 'Test Check Item',
+        name: 'test1',
+        type: 'test',
         description: 'Test check description',
         totalCheckCount: 5,
         issueCount: 2,
+        canRetry: true,
         steps: {
           step1: {
             name: 'Step 1',
@@ -30,12 +32,16 @@ export function getMockCheckSummary(): CheckSummaryType {
                 links: [],
                 severity: Severity.High,
                 stepID: 'step1',
+                itemID: 'item1',
+                isRetrying: false,
               },
               {
                 item: 'Issue 2',
                 links: [],
                 severity: Severity.High,
                 stepID: 'step1',
+                itemID: 'item2',
+                isRetrying: false,
               },
             ],
           },
@@ -47,25 +53,30 @@ export function getMockCheckSummary(): CheckSummaryType {
 
 describe('CheckSummary', () => {
   const mockCheckSummary = getMockCheckSummary();
+  const defaultProps = {
+    checkSummary: mockCheckSummary,
+    retryCheck: jest.fn(),
+    isCompleted: true,
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders check summary title with correct count', () => {
-    renderWithRouter(<CheckSummary checkSummary={mockCheckSummary} />);
+    renderWithRouter(<CheckSummary {...defaultProps} />);
     expect(screen.getByText(/2 items needs to be fixed/i)).toBeInTheDocument();
   });
 
   it('shows drilldown content when expanded', async () => {
     const user = userEvent.setup();
-    renderWithRouter(<CheckSummary checkSummary={mockCheckSummary} />);
+    renderWithRouter(<CheckSummary {...defaultProps} />);
 
     // Click to expand
     await user.click(screen.getByText(/Test Check/i));
 
     // Check if drilldown content is visible
-    expect(screen.getByText('Step 1 failed for 2 Test Check Items.')).toBeInTheDocument();
+    expect(screen.getByText('Step 1 failed for 2 tests.')).toBeInTheDocument();
 
     // Click to expand step 1
     await user.click(screen.getByText(/Step 1/i));
@@ -92,7 +103,7 @@ describe('CheckSummary', () => {
       },
     };
 
-    const { container } = renderWithRouter(<CheckSummary checkSummary={noIssuesCheckSummary} />);
+    const { container } = renderWithRouter(<CheckSummary {...defaultProps} checkSummary={noIssuesCheckSummary} />);
     expect(container.firstChild).toBeNull();
   });
 });

--- a/src/components/CheckSummary.tsx
+++ b/src/components/CheckSummary.tsx
@@ -9,10 +9,11 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 interface Props {
   checkSummary: CheckSummaryType;
-  isActive?: boolean;
+  retryCheck: (checkName: string, item: string) => void;
+  isCompleted: boolean;
 }
 
-export function CheckSummary({ checkSummary }: Props) {
+export function CheckSummary({ checkSummary, retryCheck, isCompleted }: Props) {
   const [isOpen, setIsOpen] = React.useState(false);
   const styles = useStyles2(getStyles(checkSummary.severity));
   const issueCount = Object.values(checkSummary.checks).reduce((acc, check) => acc + check.issueCount, 0);
@@ -53,7 +54,7 @@ export function CheckSummary({ checkSummary }: Props) {
     >
       {/* Issues */}
       <div className={styles.issues}>
-        <CheckDrillDown checkSummary={checkSummary} />
+        <CheckDrillDown checkSummary={checkSummary} retryCheck={retryCheck} isCompleted={isCompleted} />
       </div>
     </Collapse>
   );

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -16,9 +16,9 @@ export function MoreInfo({ checkSummaries }: Props) {
     <Collapse label={'More info'} isOpen={isOpen} onToggle={() => setIsOpen(!isOpen)} collapsible={true}>
       <div className={styles.container}>
         {Object.values(checkSummaries.high.checks).map((check) => (
-          <div key={check.name} className={styles.check}>
+          <div key={check.type} className={styles.check}>
             <div className={styles.checkTitle}>
-              {check.totalCheckCount} {check.name}(s) analyzed
+              {check.totalCheckCount} {check.type}(s) analyzed
             </div>
             <div>
               {Object.values(check.steps).map((step) => (

--- a/src/generated/endpoints.gen.ts
+++ b/src/generated/endpoints.gen.ts
@@ -1,7 +1,3 @@
-/**
- * This file is copied from grafana/grafana and has been auto-generated.
- * https://github.com/grafana/grafana/blob/main/public/app/api/clients/advisor/endpoints.gen.ts
- */
 import { api } from './baseAPI';
 export const addTagTypes = ['Check', 'CheckType'] as const;
 const injectedRtkApi = api
@@ -112,7 +108,7 @@ export type ListCheckApiArg = {
   /** allowWatchBookmarks requests watch events with type "BOOKMARK". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. */
   allowWatchBookmarks?: boolean;
   /** The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the "next key".
-   
+    
     This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications. */
   continue?: string;
   /** A selector to restrict the list of returned objects by their fields. Defaults to everything. */
@@ -120,19 +116,19 @@ export type ListCheckApiArg = {
   /** A selector to restrict the list of returned objects by their labels. Defaults to everything. */
   labelSelector?: string;
   /** limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
-   
+    
     The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned. */
   limit?: number;
   /** resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
-   
+    
     Defaults to unset */
   resourceVersion?: string;
   /** resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
-   
+    
     Defaults to unset */
   resourceVersionMatch?: string;
   /** `sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic "Bookmark" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `"k8s.io/initial-events-end": "true"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.
-   
+    
     When `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan
       is interpreted as "data at least as new as the provided `resourceVersion`"
       and the bookmark event is send when the state is synced
@@ -142,7 +138,7 @@ export type ListCheckApiArg = {
       when request started being processed.
     - `resourceVersionMatch` set to any other value or unset
       Invalid error is returned.
-   
+    
     Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward compatibility reasons) and to false otherwise. */
   sendInitialEvents?: boolean;
   /** Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity. */
@@ -150,9 +146,10 @@ export type ListCheckApiArg = {
   /** Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion. */
   watch?: boolean;
 };
-export type CreateCheckApiResponse =
-  /** status 200 OK */
-  Check | /** status 201 Created */ Check | /** status 202 Accepted */ Check;
+export type CreateCheckApiResponse = /** status 200 OK */
+  | Check
+  | /** status 201 Created */ Check
+  | /** status 202 Accepted */ Check;
 export type CreateCheckApiArg = {
   /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
   pretty?: string;
@@ -211,7 +208,7 @@ export type ListCheckTypeApiArg = {
   /** allowWatchBookmarks requests watch events with type "BOOKMARK". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored. */
   allowWatchBookmarks?: boolean;
   /** The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the "next key".
-   
+    
     This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications. */
   continue?: string;
   /** A selector to restrict the list of returned objects by their fields. Defaults to everything. */
@@ -219,19 +216,19 @@ export type ListCheckTypeApiArg = {
   /** A selector to restrict the list of returned objects by their labels. Defaults to everything. */
   labelSelector?: string;
   /** limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
-   
+    
     The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned. */
   limit?: number;
   /** resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
-   
+    
     Defaults to unset */
   resourceVersion?: string;
   /** resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
-   
+    
     Defaults to unset */
   resourceVersionMatch?: string;
   /** `sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic "Bookmark" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `"k8s.io/initial-events-end": "true"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.
-   
+    
     When `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan
       is interpreted as "data at least as new as the provided `resourceVersion`"
       and the bookmark event is send when the state is synced
@@ -241,7 +238,7 @@ export type ListCheckTypeApiArg = {
       when request started being processed.
     - `resourceVersionMatch` set to any other value or unset
       Invalid error is returned.
-   
+    
     Defaults to true if `resourceVersion=""` or `resourceVersion="0"` (for backward compatibility reasons) and to false otherwise. */
   sendInitialEvents?: boolean;
   /** Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity. */
@@ -287,21 +284,21 @@ export type ObjectMeta = {
     [key: string]: string;
   };
   /** CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-   
+    
     Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata */
   creationTimestamp?: Time;
   /** Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only. */
   deletionGracePeriodSeconds?: number;
   /** DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
-   
+    
     Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata */
   deletionTimestamp?: Time;
   /** Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list. */
   finalizers?: string[];
   /** GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-   
+    
     If this field is specified and the generated name exists, the server will return a 409.
-   
+    
     Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency */
   generateName?: string;
   /** A sequence number representing a specific generation of the desired state. Populated by the system. Read-only. */
@@ -315,19 +312,19 @@ export type ObjectMeta = {
   /** Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names */
   name?: string;
   /** Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-   
+    
     Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces */
   namespace?: string;
   /** List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. */
   ownerReferences?: OwnerReference[];
   /** An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-   
+    
     Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency */
   resourceVersion?: string;
   /** Deprecated: selfLink is a legacy read-only field that is no longer populated by the system. */
   selfLink?: string;
   /** UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-   
+    
     Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids */
   uid?: string;
 };
@@ -358,6 +355,8 @@ export type CheckErrorLink = {
 export type CheckReportFailure = {
   /** Human readable identifier of the item that failed */
   item: string;
+  /** ID of the item that failed */
+  itemID: string;
   /** Links to actions that can be taken to resolve the failure */
   links: CheckErrorLink[];
   /** Severity of the failure */
@@ -411,7 +410,7 @@ export type CheckList = {
 };
 export type StatusCause = {
   /** The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
-   
+    
     Examples:
       "name" - the field "name" on the current resource
       "items[0].name" - the field "name" on the first array entry in "items" */

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -4,7 +4,23 @@
  */
 import { generatedAPI } from './endpoints.gen';
 
-export const advisorAPI = generatedAPI;
+export const advisorAPI = generatedAPI.enhanceEndpoints({
+  endpoints: {
+    // Need to mutate the generated query to set the Content-Type header correctly
+    updateCheck: (endpointDefinition) => {
+      const originalQuery = endpointDefinition.query;
+      if (originalQuery) {
+        endpointDefinition.query = (requestOptions) => ({
+          ...originalQuery(requestOptions),
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+          body: JSON.stringify(requestOptions.patch),
+        });
+      }
+    },
+  },
+});
 export const {
   useGetCheckQuery,
   useListCheckQuery,
@@ -13,5 +29,4 @@ export const {
   useUpdateCheckMutation,
   useListCheckTypeQuery,
 } = advisorAPI;
-
 export { type Check, type CheckType } from './endpoints.gen';

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -15,11 +15,13 @@ jest.mock('@grafana/runtime', () => ({
   ),
 }));
 
-const mockCheck = (name: string, description: string, issueCount: number) => ({
+const mockCheck = (name: string, type: string, description: string, issueCount: number) => ({
   name,
+  type,
   description,
   totalCheckCount: issueCount,
   issueCount,
+  canRetry: true,
   steps: {},
 });
 
@@ -30,8 +32,8 @@ const defaultSummaries = {
     description: 'High priority issues',
     severity: Severity.High,
     checks: {
-      'check-1': mockCheck('Check 1', 'First check', 1),
-      'check-2': mockCheck('Check 2', 'Second check', 2),
+      'check-1': mockCheck('check-1', 'datasource', 'Check 1', 1),
+      'check-2': mockCheck('check-2', 'datasource', 'Check 2', 2),
     },
   },
   low: {
@@ -40,7 +42,7 @@ const defaultSummaries = {
     description: 'Low priority issues',
     severity: Severity.Low,
     checks: {
-      'check-3': mockCheck('Check 3', 'Third check', 1),
+      'check-3': mockCheck('check-3', 'datasource', 'Check 3', 1),
     },
   },
 } as CheckSummaries;
@@ -49,6 +51,10 @@ const mockUseCheckSummaries = jest.fn();
 const mockUseCompletedChecks = jest.fn();
 const mockUseCreateChecks = jest.fn();
 const mockUseDeleteChecks = jest.fn();
+const mockUseRetryCheck = jest.fn().mockReturnValue({
+  retryCheck: jest.fn(),
+  retryCheckState: { isError: false, error: undefined },
+});
 
 // Mock the entire api module
 jest.mock('api/api', () => ({
@@ -56,6 +62,7 @@ jest.mock('api/api', () => ({
   useCompletedChecks: () => mockUseCompletedChecks(),
   useCreateChecks: () => mockUseCreateChecks(),
   useDeleteChecks: () => mockUseDeleteChecks(),
+  useRetryCheck: () => mockUseRetryCheck(),
 }));
 
 describe('Home', () => {
@@ -139,7 +146,7 @@ describe('Home', () => {
           description: 'High priority issues',
           severity: Severity.High,
           checks: {
-            'check-1': mockCheck('Check 1', 'First check', 0),
+            'check-1': mockCheck('check-1', 'datasource', 'Check 1', 0),
           },
         },
         low: {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { CheckSummary } from 'components/CheckSummary';
 import { MoreInfo } from 'components/MoreInfo';
 import Actions from 'components/Actions';
-import { useCheckSummaries } from 'api/api';
+import { useCheckSummaries, useCompletedChecks, useRetryCheck } from 'api/api';
 import { formatDate } from 'utils';
 
 export default function Home() {
@@ -14,6 +14,8 @@ export default function Home() {
   const { summaries, isLoading, isError, error } = useCheckSummaries();
   const [isEmpty, setIsEmpty] = useState(false);
   const [isHealthy, setIsHealthy] = useState(false);
+  const { isCompleted } = useCompletedChecks();
+  const { retryCheck } = useRetryCheck();
 
   useEffect(() => {
     if (!isLoading && !isError) {
@@ -23,6 +25,8 @@ export default function Home() {
         const highIssueCount = Object.values(summaries.high.checks).reduce((acc, check) => acc + check.issueCount, 0);
         const lowIssueCount = Object.values(summaries.low.checks).reduce((acc, check) => acc + check.issueCount, 0);
         setIsHealthy(highIssueCount + lowIssueCount === 0);
+      } else {
+        setIsHealthy(false);
       }
     }
   }, [isLoading, isError, summaries]);
@@ -35,7 +39,7 @@ export default function Home() {
       }}
       actions={
         <>
-          <Actions />
+          <Actions isCompleted={isCompleted} />
           {!isEmpty && (
             <div className={styles.lastChecked}>
               Last checked: <strong>{summaries ? formatDate(summaries.high.created) : '...'}</strong>
@@ -85,8 +89,8 @@ export default function Home() {
             {/* Check summaries */}
             <div className={styles.checksSummaries}>
               <Stack direction="column">
-                <CheckSummary checkSummary={summaries.high} />
-                <CheckSummary checkSummary={summaries.low} />
+                <CheckSummary checkSummary={summaries.high} retryCheck={retryCheck} isCompleted={isCompleted} />
+                <CheckSummary checkSummary={summaries.low} retryCheck={retryCheck} isCompleted={isCompleted} />
                 <MoreInfo checkSummaries={summaries} />
               </Stack>
             </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,9 +21,11 @@ export type CheckSummary = {
 // A check is a group of related validation steps (e.g. for datasources or plugins)
 export type Check = {
   name: string;
+  type: string;
   description: string;
   totalCheckCount: number;
   issueCount: number;
+  canRetry: boolean;
   steps: Record<string, CheckStep>;
 };
 
@@ -34,5 +36,9 @@ export type CheckStep = {
   resolution: string;
   stepID: string;
   issueCount: number;
-  issues: CheckReportFailure[];
+  issues: CheckReportFailureExtended[];
+};
+
+export type CheckReportFailureExtended = CheckReportFailure & {
+  isRetrying: boolean;
 };


### PR DESCRIPTION
For large instances, retriggering all the checks to verify only if one has been fixed is to slow, this PR allows user to trigger only one check.

Note that while one check is being retried, the apps prevent the user from retrying other checks since the system only supports retrying one check at a time.

Demo (the check is aritifically made slow to be able to properly see the loading behavior):

https://github.com/user-attachments/assets/fedf28ca-1aca-4f71-8876-c343d86ebad1

_Requires changes from https://github.com/grafana/grafana/pull/104279 but the feature is backwards compatible (it won't show the retry button if the backend doesn't support it)._

Completes: https://github.com/grafana/grafana-community-team/issues/366
