### PR TITLE
CD: Enable provisioned plugins Argo Workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,3 +33,4 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       # Disable playwright tests for now
       run-playwright: false
+      grafana-cloud-deployment-type: provisioned

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,3 +34,4 @@ jobs:
       # Disable playwright tests for now
       run-playwright: false
       grafana-cloud-deployment-type: provisioned
+      argo-workflow-slack-channel: "#grafana-plugins-platform-ci"


### PR DESCRIPTION
Trigger Argo CD workflow to deploy the plugin to Grafana Cloud using Argo Workflows.

Requires https://github.com/grafana/deployment_tools/pull/259635

Part of https://github.com/grafana/grafana-community-team/issues/414