### PR TITLE
Some minor fixes

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -132,7 +132,7 @@ describe('API Hooks', () => {
               name: 'check2',
               labels: { [CHECK_TYPE_LABEL]: 'type1' },
               creationTimestamp: '2024-01-02T00:00:00Z',
-              annotations: { [STATUS_ANNOTATION]: 'unprocessed' },
+              annotations: {},
             },
             status: { report: { count: 1, failures: [] } },
           },
@@ -486,6 +486,53 @@ describe('API Hooks', () => {
         result.current.setShowHiddenIssues(true);
       });
       expect(result.current.summaries.high.checks.type1.steps.step1.issueCount).toBe(1);
+    });
+    it('shows an errored check', async () => {
+      const mockCheckTypes = {
+        items: [
+          {
+            metadata: { name: 'type1' },
+            spec: {
+              name: 'type1',
+              steps: [{ stepID: 'step1', title: 'Step 1', description: 'desc', resolution: 'res' }],
+            },
+          },
+        ],
+      };
+
+      const mockChecks = {
+        items: [
+          {
+            metadata: {
+              name: 'check1',
+              labels: { [CHECK_TYPE_LABEL]: 'type1' },
+              creationTimestamp: '2024-01-01T00:00:00Z',
+              annotations: { [STATUS_ANNOTATION]: 'error' },
+            },
+            status: {
+              report: {
+                count: 1,
+                failures: [{ stepID: 'step1', severity: 'High', itemID: 'item1' }],
+              },
+            },
+          },
+        ],
+      };
+
+      mockListCheckTypeQuery.mockReturnValue({
+        data: mockCheckTypes,
+        isLoading: false,
+        isError: false,
+      });
+
+      mockListCheckQuery.mockReturnValue({
+        data: mockChecks,
+        isLoading: false,
+        isError: false,
+      });
+
+      const { result } = renderHook(() => useCheckSummaries());
+      expect(result.current.isError).toBe(true);
     });
   });
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -22,6 +22,7 @@ export function useCheckSummaries() {
   const { checks, ...listChecksState } = useLastChecks();
   const { checkTypes, ...listCheckTypesState } = useCheckTypes();
   const [showHiddenIssues, setShowHiddenIssues] = useState(false);
+  const [hasError, setHasError] = useState(false);
   const { isIssueHidden, handleHideIssue } = useHiddenIssues();
 
   const summaries = useMemo(() => {
@@ -47,6 +48,10 @@ export function useCheckSummaries() {
 
       if (checkType === undefined || !checkSummary[Severity.High].checks[checkType]) {
         continue;
+      }
+
+      if (check.metadata.annotations?.[STATUS_ANNOTATION] === 'error') {
+        setHasError(true);
       }
 
       checkSummary[Severity.High].checks[checkType].totalCheckCount = check.status.report.count;
@@ -110,7 +115,7 @@ export function useCheckSummaries() {
   return {
     summaries,
     isLoading: listChecksState.isLoading || listCheckTypesState.isLoading,
-    isError: listChecksState.isError || listCheckTypesState.isError,
+    isError: listChecksState.isError || listCheckTypesState.isError || hasError,
     error: listChecksState.error || listCheckTypesState.error,
     showHiddenIssues,
     setShowHiddenIssues,
@@ -236,11 +241,7 @@ export function useLastChecks() {
     for (const check of data.items) {
       const type = check.metadata.labels?.[CHECK_TYPE_LABEL];
 
-      if (
-        !type ||
-        !check.metadata.creationTimestamp ||
-        check.metadata.annotations?.[STATUS_ANNOTATION] !== 'processed'
-      ) {
+      if (!type || !check.metadata.creationTimestamp || !check.metadata.annotations?.[STATUS_ANNOTATION]) {
         continue;
       }
 
@@ -332,7 +333,8 @@ function useIncompleteChecks(names?: string[]) {
       .filter(
         (check) =>
           !check.metadata.annotations?.[STATUS_ANNOTATION] ||
-          check.metadata.annotations?.[RETRY_ANNOTATION] !== undefined
+          (check.metadata.annotations?.[RETRY_ANNOTATION] !== undefined &&
+            check.metadata.annotations?.[STATUS_ANNOTATION] !== 'error')
       )
       .map((check) => check.metadata.name ?? '');
   }, [listChecksState.data, names]);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/css';
-import { EmptyState, Icon, LoadingPlaceholder, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, EmptyState, Icon, LoadingPlaceholder, Stack, useStyles2 } from '@grafana/ui';
 import { isFetchError, PluginPage } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import { CheckSummary } from 'components/CheckSummary';
@@ -19,7 +19,7 @@ export default function Home() {
   const { retryCheck } = useRetryCheck();
 
   useEffect(() => {
-    if (!isLoading && !isError) {
+    if (!isLoading && !isError && isCompleted) {
       const isEmptyTemp = summaries.high.created.getTime() === 0;
       setIsEmpty(isEmptyTemp);
       if (!isEmptyTemp) {
@@ -30,7 +30,7 @@ export default function Home() {
         setIsHealthy(false);
       }
     }
-  }, [isLoading, isError, summaries]);
+  }, [isLoading, isError, summaries, isCompleted]);
 
   return (
     <PluginPage
@@ -71,10 +71,12 @@ export default function Home() {
         )}
 
         {/* Error */}
-        {isError && isFetchError(error) && (
-          <div>
-            Error: {error.status} {error.statusText}
-          </div>
+        {isError && (
+          <Alert title="Failed to load checks" className={styles.error}>
+            {isFetchError(error)
+              ? `${error.status} ${error.statusText}`
+              : 'Check server logs for more details or open a support ticket.'}
+          </Alert>
         )}
 
         {/* Empty state */}
@@ -156,5 +158,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     ':hover': {
       color: theme.colors.text.link,
     },
+  }),
+  error: css({
+    marginTop: theme.spacing(2),
   }),
 });


### PR DESCRIPTION
This PR fixes a couple of issues:

 - When the backend fails to run a check (unexpected error), it sets the status annotation as "error". Added the logic here to handle that case and show an error alert:
<img width="1200" alt="Screenshot 2025-05-20 at 13 11 25" src="https://github.com/user-attachments/assets/09afc2fc-e3fe-43da-92b0-a7d23945736b" />

 - When refreshing a report the message "no issues found" was temporarily shown before all checks were completed. This PR avoids showing that message until all the checks are completed.