### PR TITLE
Use check type name annotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advisor",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advisor",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -14,6 +14,7 @@ import { CheckTypeSpec } from 'generated/endpoints.gen';
 
 export const STATUS_ANNOTATION = 'advisor.grafana.app/status';
 export const CHECK_TYPE_LABEL = 'advisor.grafana.app/type';
+export const CHECK_TYPE_NAME_ANNOTATION = 'advisor.grafana.app/checktype-name';
 export const RETRY_ANNOTATION = 'advisor.grafana.app/retry';
 export const IGNORE_STEPS_ANNOTATION = 'advisor.grafana.app/ignore-steps';
 export const IGNORE_STEPS_ANNOTATION_LIST = 'advisor.grafana.app/ignore-steps-list';
@@ -50,14 +51,17 @@ export function useCheckSummaries() {
         continue;
       }
 
+      const checkTypeDefinition = checkTypes.find((ct) => ct.metadata.name === checkType);
+
       if (check.metadata.annotations?.[STATUS_ANNOTATION] === 'error') {
         setHasError(true);
       }
 
       checkSummary[Severity.High].checks[checkType].totalCheckCount = check.status.report.count;
+      checkSummary[Severity.High].checks[checkType].typeName =
+        checkTypeDefinition?.metadata.annotations?.[CHECK_TYPE_NAME_ANNOTATION] ?? checkType;
       checkSummary[Severity.High].checks[checkType].name = check.metadata.name ?? '';
       checkSummary[Severity.Low].checks[checkType].name = check.metadata.name ?? '';
-      const checkTypeDefinition = checkTypes.find((ct) => ct.metadata.name === checkType);
       const canRetry = !!checkTypeDefinition?.metadata.annotations?.[RETRY_ANNOTATION];
       // Enable retry if the check type has a retry annotation
       checkSummary[Severity.High].checks[checkType].canRetry = canRetry;

--- a/src/components/CheckSummary.test.tsx
+++ b/src/components/CheckSummary.test.tsx
@@ -15,6 +15,7 @@ export function getMockCheckSummary(): CheckSummaryType {
       testCheck: {
         name: 'test1',
         type: 'test',
+        typeName: 'Test Type',
         description: 'Test check description',
         totalCheckCount: 5,
         issueCount: 2,

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -40,7 +40,7 @@ export function MoreInfo({ checkSummaries, showHiddenIssues, setShowHiddenIssues
         {Object.values(checkSummaries.high.checks).map((check) => (
           <div key={check.type} className={styles.check}>
             <div className={styles.checkTitle}>
-              {check.totalCheckCount} {check.type}(s) analyzed
+              {check.totalCheckCount} {check.typeName || check.type}(s) analyzed
             </div>
             <div>
               {Object.values(check.steps).map((step) => (

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -18,6 +18,7 @@ jest.mock('@grafana/runtime', () => ({
 const mockCheck = (name: string, type: string, description: string, issueCount: number) => ({
   name,
   type,
+  typeName: type,
   description,
   totalCheckCount: issueCount,
   issueCount,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type CheckSummary = {
 export type Check = {
   name: string;
   type: string;
+  typeName: string;
   description: string;
   totalCheckCount: number;
   issueCount: number;

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -42,8 +42,8 @@ test.describe('navigating app', () => {
     // Click on the "More Info"
     await page.getByText('More Info').click();
     // Page should now show a report
-    await expect(page.getByText('datasource(s) analyzed')).toBeVisible();
-    await expect(page.getByText('plugin(s) analyzed')).toBeVisible();
+    await expect(page.getByText(/(datasource|Data Source)\(s\) analyzed/)).toBeVisible();
+    await expect(page.getByText(/(plugin|Plugin)\(s\) analyzed/)).toBeVisible();
   });
 
   test('it should detect an issue and fix it', async ({ gotoPage, page, grafanaVersion }) => {


### PR DESCRIPTION
If the annotation is present, use the human-readable version of the check type name (e.g. `Data Source` vs `datasource`):

![image](https://github.com/user-attachments/assets/3a078df1-bcaf-48f3-ac92-51ac4b35efda)

Also bump the version to prepare for a new release.
