### PR TITLE
Show status for each check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advisor",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advisor",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",
@@ -15,6 +15,7 @@
         "@grafana/schema": "^11.5.3",
         "@grafana/ui": "^11.5.3",
         "@reduxjs/toolkit": "^2.6.1",
+        "date-fns": "^4.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
@@ -73,6 +73,7 @@
     "@grafana/schema": "^11.5.3",
     "@grafana/ui": "^11.5.3",
     "@reduxjs/toolkit": "^2.6.1",
+    "date-fns": "^4.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "^6.22.0",

--- a/src/components/Actions/Actions.test.tsx
+++ b/src/components/Actions/Actions.test.tsx
@@ -29,7 +29,7 @@ describe('Actions', () => {
   });
 
   it('renders refresh and delete buttons', async () => {
-    render(<Actions isCompleted={true} />);
+    render(<Actions isCompleted={true} checkStatuses={[]} />);
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /delete reports/i })).toBeInTheDocument();
@@ -37,7 +37,7 @@ describe('Actions', () => {
   });
 
   it('shows loading state when running checks', async () => {
-    render(<Actions isCompleted={false} />);
+    render(<Actions isCompleted={false} checkStatuses={[]} />);
     await waitFor(() => {
       expect(screen.getByText('Running checks...')).toBeInTheDocument();
     });
@@ -55,14 +55,14 @@ describe('Actions', () => {
       createCheckState: { isError: true, error },
     });
 
-    render(<Actions isCompleted={true} />);
+    render(<Actions isCompleted={true} checkStatuses={[]} />);
     await waitFor(() => {
       expect(screen.getByText(/error while running checks: 500 internal server error/i)).toBeInTheDocument();
     });
   });
 
   it('shows confirmation modal when delete button clicked', async () => {
-    render(<Actions isCompleted={true} />);
+    render(<Actions isCompleted={true} checkStatuses={[]} />);
     const deleteButton = screen.getByRole('button', { name: /delete reports/i });
     await user.click(deleteButton);
 
@@ -79,7 +79,7 @@ describe('Actions', () => {
       deleteChecksState: { isLoading: false, isError: false, error: undefined },
     });
 
-    render(<Actions isCompleted={true} />);
+    render(<Actions isCompleted={true} checkStatuses={[]} />);
     const deleteButton = screen.getByRole('button', { name: /delete reports/i });
     await user.click(deleteButton);
 
@@ -103,7 +103,7 @@ describe('Actions', () => {
       deleteChecksState: { isLoading: false, isError: true, error },
     });
 
-    render(<Actions isCompleted={true} />);
+    render(<Actions isCompleted={true} checkStatuses={[]} />);
     await waitFor(() => {
       expect(screen.getByText(/error deleting checks: 500 internal server error/i)).toBeInTheDocument();
     });
@@ -116,7 +116,7 @@ describe('Actions', () => {
       createCheckState: { isError: false, error: undefined },
     });
 
-    render(<Actions isCompleted={true} />);
+    render(<Actions isCompleted={true} checkStatuses={[]} />);
     const refreshButton = screen.getByRole('button', { name: /refresh/i });
     await user.click(refreshButton);
 

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -4,8 +4,15 @@ import { isFetchError } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useDeleteChecks, useCreateChecks } from 'api/api';
+import { CheckStatus } from 'types';
+import ChecksStatus from './ChecksStatus';
 
-export default function Actions({ isCompleted }: { isCompleted: boolean }) {
+interface ActionsProps {
+  isCompleted: boolean;
+  checkStatuses: CheckStatus[];
+}
+
+export default function Actions({ isCompleted, checkStatuses }: ActionsProps) {
   const { createChecks, createCheckState } = useCreateChecks();
   const { deleteChecks, deleteChecksState } = useDeleteChecks();
   const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
@@ -35,7 +42,7 @@ export default function Actions({ isCompleted }: { isCompleted: boolean }) {
             }}
             disabled={!isCompleted}
             variant="secondary"
-            icon={!isCompleted ? 'spinner' : 'sync'}
+            icon={isCompleted ? 'sync' : 'spinner'}
           >
             {isCompleted ? 'Refresh' : 'Running checks...'}
           </Button>
@@ -47,6 +54,8 @@ export default function Actions({ isCompleted }: { isCompleted: boolean }) {
             aria-label="Delete reports"
           ></Button>
         </Stack>
+
+        <ChecksStatus checkStatuses={checkStatuses} />
 
         <div className={styles.rightColumn}>
           {createCheckState.isError && isFetchError(createCheckState.error) && (

--- a/src/components/Actions/CheckError.test.tsx
+++ b/src/components/Actions/CheckError.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CheckError from './CheckError';
+
+describe('CheckError', () => {
+  it('renders error message', () => {
+    render(<CheckError />);
+
+    expect(screen.getByText('Check failed to complete. See server logs for details or try again.')).toBeInTheDocument();
+  });
+});

--- a/src/components/Actions/CheckError.tsx
+++ b/src/components/Actions/CheckError.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+
+export default function CheckError() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.errorContainer}>
+      <span className={styles.errorText}>Check failed to complete. See server logs for details or try again.</span>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  errorContainer: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginLeft: theme.spacing(3),
+    padding: theme.spacing(0.5),
+    borderRadius: theme.shape.radius.default,
+  }),
+  errorText: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.primary,
+  }),
+});

--- a/src/components/Actions/CheckWarning.test.tsx
+++ b/src/components/Actions/CheckWarning.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CheckWarning from './CheckWarning';
+
+describe('CheckWarning', () => {
+  it('renders warning message for checks older than 5 seconds', () => {
+    const twentyMinutesAgo = new Date(Date.now() - 20 * 60 * 1000);
+    render(<CheckWarning checkCreated={twentyMinutesAgo} />);
+
+    expect(screen.getByText(/Check is taking longer than expected \(started 20 minutes ago\)/)).toBeInTheDocument();
+  });
+});

--- a/src/components/Actions/CheckWarning.tsx
+++ b/src/components/Actions/CheckWarning.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Icon, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+import { formatDistanceToNow } from 'date-fns';
+
+interface CheckWarningProps {
+  checkCreated: Date;
+}
+
+export default function CheckWarning({ checkCreated }: CheckWarningProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.warningContainer}>
+      <Icon name="exclamation-triangle" className={styles.warningIcon} />
+      <span className={styles.warningText}>
+        Check is taking longer than expected (started {formatDistanceToNow(checkCreated)} ago). Inspect server logs for
+        errors or delete and re-create the report to retry.
+      </span>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  warningContainer: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginLeft: theme.spacing(3),
+    padding: theme.spacing(0.5),
+    borderRadius: theme.shape.radius.default,
+  }),
+  warningIcon: css({
+    color: theme.colors.warning.text,
+    marginRight: theme.spacing(0.5),
+  }),
+  warningText: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.primary,
+  }),
+});

--- a/src/components/Actions/ChecksStatus.test.tsx
+++ b/src/components/Actions/ChecksStatus.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RunningChecksStatus from './ChecksStatus';
+import { CheckStatus } from 'types';
+
+describe('RunningChecksStatus', () => {
+  const user = userEvent.setup();
+
+  const oldDate = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+  const mockCheckStatuses: CheckStatus[] = [
+    {
+      name: 'datasource',
+      creationTimestamp: oldDate,
+      incomplete: true,
+      hasError: false,
+    },
+    {
+      name: 'plugin',
+      creationTimestamp: oldDate,
+      incomplete: false,
+      hasError: false,
+    },
+  ];
+
+  it('does not render when completed and no errors', () => {
+    const { container } = render(
+      <RunningChecksStatus
+        checkStatuses={[
+          {
+            name: 'datasource',
+            creationTimestamp: new Date().toISOString(),
+            incomplete: false,
+            hasError: false,
+          },
+        ]}
+      />
+    );
+
+    expect(container.firstChild?.firstChild).toBeNull();
+  });
+
+  it('renders when not completed', () => {
+    render(<RunningChecksStatus checkStatuses={mockCheckStatuses} />);
+
+    expect(screen.getByText('Show checks status')).toBeInTheDocument();
+  });
+
+  it('renders when there are errors', () => {
+    const checkStatusesWithError: CheckStatus[] = [
+      {
+        name: 'datasource',
+        creationTimestamp: new Date().toISOString(),
+        incomplete: false,
+        hasError: true,
+      },
+    ];
+
+    render(<RunningChecksStatus checkStatuses={checkStatusesWithError} />);
+
+    expect(screen.getByText('Show checks status')).toBeInTheDocument();
+  });
+
+  it('expands to show check details when clicked', async () => {
+    render(<RunningChecksStatus checkStatuses={mockCheckStatuses} />);
+
+    const expandButton = screen.getByText('Show checks status');
+    await user.click(expandButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Check types')).toBeInTheDocument();
+      expect(screen.getByText('datasource')).toBeInTheDocument();
+      expect(screen.getByText('plugin')).toBeInTheDocument();
+    });
+  });
+
+  it('shows CheckWarning for incomplete checks', async () => {
+    render(<RunningChecksStatus checkStatuses={mockCheckStatuses} />);
+
+    const expandButton = screen.getByText('Show checks status');
+    await user.click(expandButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Check is taking longer than expected/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows CheckError for failed checks', async () => {
+    const checkStatusesWithError: CheckStatus[] = [
+      {
+        name: 'datasource',
+        creationTimestamp: new Date().toISOString(),
+        incomplete: false,
+        hasError: true,
+      },
+    ];
+
+    render(<RunningChecksStatus checkStatuses={checkStatusesWithError} />);
+
+    const expandButton = screen.getByText('Show checks status');
+    await user.click(expandButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Check failed to complete/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Actions/ChecksStatus.tsx
+++ b/src/components/Actions/ChecksStatus.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { Stack, useStyles2, Icon, Collapse } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+import { CheckStatus } from 'types';
+import CheckWarning from './CheckWarning';
+import CheckError from './CheckError';
+import { isOld } from 'utils';
+
+interface RunningChecksStatusProps {
+  checkStatuses: CheckStatus[];
+}
+
+export default function ChecksStatus({ checkStatuses }: RunningChecksStatusProps) {
+  const [isStatusExpanded, setIsStatusExpanded] = useState(false);
+  const styles = useStyles2(getStyles);
+  const hasError = checkStatuses.some((check) => check.hasError);
+  const hasOldChecks = checkStatuses.some(isOld);
+  const allChecksCompleted = checkStatuses.every((check) => !check.incomplete);
+
+  return (
+    <Stack direction="row" gap={1}>
+      {(!allChecksCompleted || hasError) && (
+        <div className={styles.statusSection}>
+          <Collapse
+            collapsible
+            isOpen={isStatusExpanded}
+            onToggle={() => setIsStatusExpanded(!isStatusExpanded)}
+            label={
+              <div className={styles.collapseLabel}>
+                {hasError && <Icon name="exclamation-circle" className={styles.errorIcon} />}
+                {hasOldChecks && !hasError && <Icon name="exclamation-triangle" className={styles.warningIcon} />}
+                <span>Show checks status</span>
+              </div>
+            }
+            className={styles.collapseContainer}
+          >
+            <div className={styles.checksHeader}>Check types</div>
+            <div className={styles.checksContainer}>
+              {checkStatuses.map((check, index) => {
+                const checkCreated = new Date(check.creationTimestamp);
+
+                return (
+                  <div key={`${check.name}-${index}`} className={styles.checkItemWrapper}>
+                    <div className={styles.checkItem}>
+                      {check.hasError && <Icon name="exclamation-circle" className={styles.errorIcon} />}
+                      {check.incomplete && <Icon name="spinner" className={styles.spinnerIcon} />}
+                      {!check.incomplete && !check.hasError && <Icon name="check" className={styles.completedIcon} />}
+                      <span className={styles.checkName}>{check.name}</span>
+                    </div>
+                    {check.incomplete && isOld(check) && <CheckWarning checkCreated={checkCreated} />}
+                    {check.hasError && <CheckError />}
+                  </div>
+                );
+              })}
+            </div>
+          </Collapse>
+        </div>
+      )}
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  statusSection: css({
+    position: 'relative',
+    zIndex: 1001,
+  }),
+  collapseLabel: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    '&:hover': {
+      color: theme.colors.text.primary,
+    },
+  }),
+  checksContainer: css({
+    maxWidth: '300px',
+    padding: theme.spacing(2),
+    backgroundColor: theme.colors.background.primary,
+    borderRadius: theme.shape.radius.default,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    position: 'relative',
+    zIndex: 1002,
+  }),
+  checkItem: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  completedIcon: css({
+    color: theme.colors.success.text,
+  }),
+  spinnerIcon: css({
+    color: theme.colors.primary.text,
+  }),
+  errorIcon: css({
+    color: theme.colors.error.text,
+  }),
+  warningIcon: css({
+    color: theme.colors.warning.text,
+  }),
+  checkName: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.primary,
+  }),
+  checksHeader: css({
+    paddingLeft: theme.spacing(0.5),
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    fontWeight: theme.typography.fontWeightMedium,
+  }),
+  collapseContainer: css({
+    border: 'none',
+  }),
+  checkItemWrapper: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+    padding: theme.spacing(0.5),
+    borderRadius: theme.shape.radius.default,
+    '&:hover': {
+      backgroundColor: theme.colors.background.secondary,
+    },
+  }),
+});

--- a/src/generated/baseAPI.ts
+++ b/src/generated/baseAPI.ts
@@ -6,28 +6,14 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 
 import { createBaseQuery } from './createBaseQuery';
 import { getAPIBaseURL } from './utils';
+import { config } from '@grafana/runtime';
 
 export const BASE_URL = getAPIBaseURL('advisor.grafana.app', 'v0alpha1');
 
-function createAdvisorApi() {
-  try {
-    return createApi({
-      reducerPath: 'advisorAPIv0alpha1',
-      baseQuery: createBaseQuery({
-        baseURL: BASE_URL,
-      }),
-      endpoints: () => ({}),
-    });
-  } catch (error) {
-    // Previous to Grafana 12.1
-    return createApi({
-      reducerPath: 'advisorAPI',
-      baseQuery: createBaseQuery({
-        baseURL: BASE_URL,
-      }),
-      endpoints: () => ({}),
-    });
-  }
-}
-
-export const api = createAdvisorApi();
+export const api = createApi({
+  reducerPath: config.buildInfo.version.startsWith('12.0') ? 'advisorAPI' : 'advisorAPIv0alpha1', // Since Grafana 12.1 the reducerPath includes the version
+  baseQuery: createBaseQuery({
+    baseURL: BASE_URL,
+  }),
+  endpoints: () => ({}),
+});

--- a/src/generated/baseAPI.ts
+++ b/src/generated/baseAPI.ts
@@ -9,10 +9,25 @@ import { getAPIBaseURL } from './utils';
 
 export const BASE_URL = getAPIBaseURL('advisor.grafana.app', 'v0alpha1');
 
-export const api = createApi({
-  reducerPath: 'advisorAPI',
-  baseQuery: createBaseQuery({
-    baseURL: BASE_URL,
-  }),
-  endpoints: () => ({}),
-});
+function createAdvisorApi() {
+  try {
+    return createApi({
+      reducerPath: 'advisorAPIv0alpha1',
+      baseQuery: createBaseQuery({
+        baseURL: BASE_URL,
+      }),
+      endpoints: () => ({}),
+    });
+  } catch (error) {
+    // Previous to Grafana 12.1
+    return createApi({
+      reducerPath: 'advisorAPI',
+      baseQuery: createBaseQuery({
+        baseURL: BASE_URL,
+      }),
+      endpoints: () => ({}),
+    });
+  }
+}
+
+export const api = createAdvisorApi();

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -1,6 +1,6 @@
 import { generatedAPI } from './endpoints.gen';
 
-export const advisorAPI = generatedAPI.enhanceEndpoints({
+export const advisorAPIv0alpha1 = generatedAPI.enhanceEndpoints({
   endpoints: {
     // Need to mutate the generated query to set the Content-Type header correctly
     updateCheck: (endpointDefinition) => {
@@ -37,5 +37,5 @@ export const {
   useUpdateCheckMutation,
   useListCheckTypeQuery,
   useUpdateCheckTypeMutation,
-} = advisorAPI;
+} = advisorAPIv0alpha1;
 export { type Check, type CheckType } from './endpoints.gen'; // eslint-disable-line

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -81,6 +81,7 @@ describe('Home', () => {
     mockUseCompletedChecks.mockReturnValue({
       isCompleted: true,
       isLoading: false,
+      checkStatuses: [],
     });
 
     mockUseCreateChecks.mockReturnValue({
@@ -215,6 +216,7 @@ describe('Home', () => {
     mockUseCompletedChecks.mockReturnValue({
       isCompleted: false,
       isLoading: false,
+      checkStatuses: [],
     });
 
     renderWithRouter(<Home />);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,7 +5,7 @@ import { isFetchError, PluginPage } from '@grafana/runtime';
 import { GrafanaTheme2 } from '@grafana/data';
 import { CheckSummary } from 'components/CheckSummary';
 import { MoreInfo } from 'components/MoreInfo';
-import Actions from 'components/Actions';
+import Actions from 'components/Actions/Actions';
 import { useCheckSummaries, useCompletedChecks, useRetryCheck } from 'api/api';
 import { formatDate } from 'utils';
 
@@ -15,7 +15,7 @@ export default function Home() {
     useCheckSummaries();
   const [isEmpty, setIsEmpty] = useState(false);
   const [isHealthy, setIsHealthy] = useState(false);
-  const { isCompleted } = useCompletedChecks();
+  const { isCompleted, checkStatuses } = useCompletedChecks();
   const { retryCheck } = useRetryCheck();
 
   useEffect(() => {
@@ -38,29 +38,28 @@ export default function Home() {
         text: 'Advisor',
         subTitle: 'Keep Grafana running smoothly and securely',
       }}
-      actions={
-        <>
-          <Actions isCompleted={isCompleted} />
-          {!isEmpty && (
-            <div className={styles.lastChecked}>
-              Last checked: <strong>{summaries ? formatDate(summaries.high.created) : '...'}</strong>
-            </div>
-          )}
-        </>
-      }
+      actions={<Actions isCompleted={isCompleted} checkStatuses={checkStatuses} />}
     >
-      <div className={styles.feedbackContainer}>
-        <Icon name="comment-alt-message" />
-        <a
-          href="https://forms.gle/oFkqRoXS8g8mnTu6A"
-          className={styles.feedback}
-          title="Share your thoughts about Grafana Advisor."
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Give feedback
-        </a>
-      </div>
+      <Stack direction="row" gap={1} justifyContent="space-between" alignItems="center">
+        <div className={styles.feedbackContainer}>
+          <Icon name="comment-alt-message" />
+          <a
+            href="https://forms.gle/oFkqRoXS8g8mnTu6A"
+            className={styles.feedback}
+            title="Share your thoughts about Grafana Advisor."
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            Give feedback
+          </a>
+        </div>
+
+        {!isEmpty && (
+          <div className={styles.lastChecked}>
+            Last checked: <strong>{summaries ? formatDate(summaries.high.created) : '...'}</strong>
+          </div>
+        )}
+      </Stack>
 
       <div className={styles.page}>
         {/* Loading */}
@@ -136,9 +135,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   lastChecked: css({
     fontSize: theme.typography.bodySmall.fontSize,
-    position: 'absolute',
-    right: theme.spacing(4),
-    top: theme.spacing(8),
   }),
   feedbackContainer: css({
     color: theme.colors.text.link,

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,3 +44,10 @@ export type CheckReportFailureExtended = CheckReportFailure & {
   isRetrying: boolean;
   isHidden: boolean;
 };
+
+export interface CheckStatus {
+  name: string;
+  creationTimestamp: string;
+  incomplete: boolean;
+  hasError: boolean;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,4 @@
-// TODO: this should come from the backend (be part of the data)
-export function formatCheckName(name: string): string {
-  const checkNameMapping: Record<string, string> = {
-    datasource: 'Datasources',
-    plugin: 'Plugins',
-  };
-
-  return checkNameMapping[name] ?? name;
-}
+import { CheckStatus } from 'types';
 
 export function formatDate(date: Date): string {
   const formatter = new Intl.DateTimeFormat('hu-HU', {
@@ -20,3 +12,8 @@ export function formatDate(date: Date): string {
 
   return formatter.format(date).replace(',', ' -');
 }
+
+export const isOld = (check: CheckStatus) => {
+  const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+  return new Date(check.creationTimestamp).getTime() < tenMinutesAgo.getTime();
+};


### PR DESCRIPTION
This PRs add a collapsible menu showing the status of the last checks executed. It's only shown while checks are running or if any check is marked as errored.

It shows a warning if one check is taking a long time to complete (more than ten minutes).

In this demo, the datasources check is made artificially slow and I reduced the threshold to 10 seconds so you can see the behavior when marking one check as "stale":

https://github.com/user-attachments/assets/b6c23a2d-4c2a-4f0b-883f-c8b27f03a5a0

Another change is that, in case one check fails, rather than showing only an error alert in the whole page, it renders the checks that completed succesfully and error message for the check that failed in the new collapsible menu.

Before:

<img width="919" alt="Screenshot 2025-06-13 at 12 41 52" src="https://github.com/user-attachments/assets/8f61793e-0029-4c0e-8550-30dbd3dcbfb5" />

After:

<img width="915" alt="Screenshot 2025-06-13 at 12 40 33" src="https://github.com/user-attachments/assets/56b01cc1-3f38-424f-bf4d-d50bbbe25a06" />

Closes https://github.com/grafana/grafana-community-team/issues/439 