### PR TITLE
chore: add dependabot configuration for GitHub Actions and npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"      
+
+  # Grafana packages - core dependencies for the plugin
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"      
+    groups:
+      grafana-packages:
+        patterns:
+          - "@grafana/*"
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-*"
+          - "@types/react*"
+      testing-tools:
+        patterns:
+          - "jest"
+          - "jest-*"
+          - "@jest/*"
+          - "@testing-library/*"
+          - "@playwright/*"
+          - "playwright"
+          - "@types/jest*"
+          - "@types/testing-library*"
+      build-tools:
+        patterns:
+          - "webpack"
+          - "webpack-*"
+          - "*-webpack-plugin"
+          - "*-loader"
+          - "@swc/*"
+          - "swc-*"
+          - "terser-*"
+          - "copy-webpack-plugin"
+          - "fork-ts-checker-webpack-plugin"
+          - "replace-in-file-webpack-plugin"
+          - "ts-node"
+          - "typescript"
+          - "@typescript-eslint/*"
+          - "eslint"
+          - "eslint-*"
+          - "@stylistic/*"
+          - "prettier"
+          - "@types/eslint*"


### PR DESCRIPTION
- Group npm packages by functionality (Grafana, React, testing, build tools, etc.)
- Include GitHub Actions updates
