### PR TITLE
Add report interaction calls

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,6 +1,12 @@
 // Jest setup provided by Grafana scaffolding
 import './.config/jest-setup';
 
+// Mock @grafana/runtime to provide usePluginInteractionReporter
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  usePluginInteractionReporter: jest.fn(() => jest.fn()),
+}));
+
 // Global mocks to avoid Redux context issues in tests
 jest.mock('api/api', () => ({
   ...jest.requireActual('api/api'),

--- a/src/api/useInteractionTracker.test.ts
+++ b/src/api/useInteractionTracker.test.ts
@@ -1,0 +1,186 @@
+import { renderHook } from '@testing-library/react';
+import { useInteractionTracker } from './useInteractionTracker';
+import { usePluginInteractionReporter } from '@grafana/runtime';
+
+// Mock @grafana/runtime
+jest.mock('@grafana/runtime', () => ({
+  usePluginInteractionReporter: jest.fn(),
+}));
+
+const mockUsePluginInteractionReporter = usePluginInteractionReporter as jest.MockedFunction<
+  typeof usePluginInteractionReporter
+>;
+
+describe('useInteractionTracker', () => {
+  let mockReport: jest.Mock;
+
+  beforeEach(() => {
+    mockReport = jest.fn();
+    mockUsePluginInteractionReporter.mockReturnValue(mockReport);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('trackGroupToggle', () => {
+    it('should track group toggle with normalized group name and open state', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackGroupToggle('Test Group Name', true);
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_group_toggled', {
+        group: 'test_group_name',
+        open: true,
+      });
+    });
+
+    it('should track group toggle with closed state', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackGroupToggle('Another Group', false);
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_group_toggled', {
+        group: 'another_group',
+        open: false,
+      });
+    });
+
+    it('should normalize group names with special characters', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackGroupToggle('Group With @#$% Special Characters!', true);
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_group_toggled', {
+        group: 'group_with__special_characters',
+        open: true,
+      });
+    });
+
+    it('should handle group names with multiple spaces', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackGroupToggle('Group   With    Multiple     Spaces', true);
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_group_toggled', {
+        group: 'group_with_multiple_spaces',
+        open: true,
+      });
+    });
+  });
+
+  describe('trackCheckInteraction', () => {
+    it('should track resolution clicked interaction', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackCheckInteraction('resolution_clicked', 'performance', 'step_123');
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_check_interaction', {
+        interaction_type: 'resolution_clicked',
+        check_type: 'performance',
+        step_id: 'step_123',
+      });
+    });
+
+    it('should track refresh clicked interaction', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackCheckInteraction('refresh_clicked', 'security', 'step_456');
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_check_interaction', {
+        interaction_type: 'refresh_clicked',
+        check_type: 'security',
+        step_id: 'step_456',
+      });
+    });
+
+    it('should track silence clicked interaction', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackCheckInteraction('silence_clicked', 'config', 'step_789', {
+        silenced: true,
+      });
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_check_interaction', {
+        interaction_type: 'silence_clicked',
+        check_type: 'config',
+        step_id: 'step_789',
+        silenced: true,
+      });
+    });
+
+    it('should track aisuggestion clicked interaction', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackCheckInteraction('aisuggestion_clicked', 'monitoring', 'step_101');
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_check_interaction', {
+        interaction_type: 'aisuggestion_clicked',
+        check_type: 'monitoring',
+        step_id: 'step_101',
+      });
+    });
+  });
+
+  describe('trackGlobalAction', () => {
+    it('should track refresh clicked global action', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackGlobalAction('refresh_clicked');
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_global_actions_interaction', {
+        action_type: 'refresh_clicked',
+      });
+    });
+
+    it('should track purge clicked global action', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackGlobalAction('purge_clicked');
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_global_actions_interaction', {
+        action_type: 'purge_clicked',
+      });
+    });
+
+    it('should track configure clicked global action', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackGlobalAction('configure_clicked');
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_global_actions_interaction', {
+        action_type: 'configure_clicked',
+      });
+    });
+  });
+
+  describe('multiple calls', () => {
+    it('should track multiple interactions correctly', () => {
+      const { result } = renderHook(() => useInteractionTracker());
+
+      // Make multiple calls
+      result.current.trackGroupToggle('Group 1', true);
+      result.current.trackCheckInteraction('resolution_clicked', 'type1', 'step1');
+      result.current.trackGlobalAction('refresh_clicked');
+      result.current.trackGroupToggle('Group 2', false);
+
+      expect(mockReport).toHaveBeenCalledTimes(4);
+      expect(mockReport).toHaveBeenNthCalledWith(1, 'grafana_plugin_advisor_group_toggled', {
+        group: 'group_1',
+        open: true,
+      });
+      expect(mockReport).toHaveBeenNthCalledWith(2, 'grafana_plugin_advisor_check_interaction', {
+        interaction_type: 'resolution_clicked',
+        check_type: 'type1',
+        step_id: 'step1',
+      });
+      expect(mockReport).toHaveBeenNthCalledWith(3, 'grafana_plugin_advisor_global_actions_interaction', {
+        action_type: 'refresh_clicked',
+      });
+      expect(mockReport).toHaveBeenNthCalledWith(4, 'grafana_plugin_advisor_group_toggled', {
+        group: 'group_2',
+        open: false,
+      });
+    });
+  });
+});

--- a/src/api/useInteractionTracker.test.ts
+++ b/src/api/useInteractionTracker.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { useInteractionTracker } from './useInteractionTracker';
+import { useInteractionTracker, CheckInteractionType, GlobalActionType } from './useInteractionTracker';
 import { usePluginInteractionReporter } from '@grafana/runtime';
 
 // Mock @grafana/runtime
@@ -70,10 +70,10 @@ describe('useInteractionTracker', () => {
   });
 
   describe('trackCheckInteraction', () => {
-    it('should track resolution clicked interaction', () => {
+    it('should track check interaction with resolution_clicked', () => {
       const { result } = renderHook(() => useInteractionTracker());
 
-      result.current.trackCheckInteraction('resolution_clicked', 'performance', 'step_123');
+      result.current.trackCheckInteraction(CheckInteractionType.RESOLUTION_CLICKED, 'performance', 'step_123');
 
       expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_check_interaction', {
         interaction_type: 'resolution_clicked',
@@ -82,10 +82,10 @@ describe('useInteractionTracker', () => {
       });
     });
 
-    it('should track refresh clicked interaction', () => {
+    it('should track check interaction with refresh_clicked', () => {
       const { result } = renderHook(() => useInteractionTracker());
 
-      result.current.trackCheckInteraction('refresh_clicked', 'security', 'step_456');
+      result.current.trackCheckInteraction(CheckInteractionType.REFRESH_CLICKED, 'security', 'step_456');
 
       expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_check_interaction', {
         interaction_type: 'refresh_clicked',
@@ -94,10 +94,10 @@ describe('useInteractionTracker', () => {
       });
     });
 
-    it('should track silence clicked interaction', () => {
+    it('should track check interaction with silence_clicked and additional properties', () => {
       const { result } = renderHook(() => useInteractionTracker());
 
-      result.current.trackCheckInteraction('silence_clicked', 'config', 'step_789', {
+      result.current.trackCheckInteraction(CheckInteractionType.SILENCE_CLICKED, 'config', 'step_789', {
         silenced: true,
       });
 
@@ -109,10 +109,10 @@ describe('useInteractionTracker', () => {
       });
     });
 
-    it('should track aisuggestion clicked interaction', () => {
+    it('should track check interaction with aisuggestion_clicked', () => {
       const { result } = renderHook(() => useInteractionTracker());
 
-      result.current.trackCheckInteraction('aisuggestion_clicked', 'monitoring', 'step_101');
+      result.current.trackCheckInteraction(CheckInteractionType.AI_SUGGESTION_CLICKED, 'monitoring', 'step_101');
 
       expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_check_interaction', {
         interaction_type: 'aisuggestion_clicked',
@@ -123,30 +123,30 @@ describe('useInteractionTracker', () => {
   });
 
   describe('trackGlobalAction', () => {
-    it('should track refresh clicked global action', () => {
+    it('should track global action with refresh_clicked', () => {
       const { result } = renderHook(() => useInteractionTracker());
 
-      result.current.trackGlobalAction('refresh_clicked');
+      result.current.trackGlobalAction(GlobalActionType.REFRESH_CLICKED);
 
       expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_global_actions_interaction', {
         action_type: 'refresh_clicked',
       });
     });
 
-    it('should track purge clicked global action', () => {
+    it('should track global action with purge_clicked', () => {
       const { result } = renderHook(() => useInteractionTracker());
 
-      result.current.trackGlobalAction('purge_clicked');
+      result.current.trackGlobalAction(GlobalActionType.PURGE_CLICKED);
 
       expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_global_actions_interaction', {
         action_type: 'purge_clicked',
       });
     });
 
-    it('should track configure clicked global action', () => {
+    it('should track global action with configure_clicked', () => {
       const { result } = renderHook(() => useInteractionTracker());
 
-      result.current.trackGlobalAction('configure_clicked');
+      result.current.trackGlobalAction(GlobalActionType.CONFIGURE_CLICKED);
 
       expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_global_actions_interaction', {
         action_type: 'configure_clicked',
@@ -160,8 +160,8 @@ describe('useInteractionTracker', () => {
 
       // Make multiple calls
       result.current.trackGroupToggle('Group 1', true);
-      result.current.trackCheckInteraction('resolution_clicked', 'type1', 'step1');
-      result.current.trackGlobalAction('refresh_clicked');
+      result.current.trackCheckInteraction(CheckInteractionType.RESOLUTION_CLICKED, 'type1', 'step1');
+      result.current.trackGlobalAction(GlobalActionType.REFRESH_CLICKED);
       result.current.trackGroupToggle('Group 2', false);
 
       expect(mockReport).toHaveBeenCalledTimes(4);

--- a/src/api/useInteractionTracker.ts
+++ b/src/api/useInteractionTracker.ts
@@ -15,10 +15,11 @@ export function useInteractionTracker() {
 
   // Group toggle tracking
   const trackGroupToggle = useCallback(
-    (groupName: string) => {
+    (groupName: string, open: boolean) => {
       const normalizedGroupName = normalizeEventName(groupName);
       report('grafana_plugin_advisor_group_toggled', {
         group: normalizedGroupName,
+        open,
       });
     },
     [report]
@@ -29,12 +30,14 @@ export function useInteractionTracker() {
     (
       interactionType: 'resolution_clicked' | 'refresh_clicked' | 'silence_clicked' | 'aisuggestion_clicked',
       checkType: string,
-      stepID: string
+      stepID: string,
+      otherProperties?: Record<string, any>
     ) => {
       report(`grafana_plugin_advisor_check_interaction`, {
         interaction_type: interactionType,
         check_type: checkType,
         step_id: stepID,
+        ...otherProperties,
       });
     },
     [report]

--- a/src/api/useInteractionTracker.ts
+++ b/src/api/useInteractionTracker.ts
@@ -1,6 +1,20 @@
 import { usePluginInteractionReporter } from '@grafana/runtime';
 import { useCallback } from 'react';
 
+// Enums for interaction types
+export enum CheckInteractionType {
+  RESOLUTION_CLICKED = 'resolution_clicked',
+  REFRESH_CLICKED = 'refresh_clicked',
+  SILENCE_CLICKED = 'silence_clicked',
+  AI_SUGGESTION_CLICKED = 'aisuggestion_clicked',
+}
+
+export enum GlobalActionType {
+  REFRESH_CLICKED = 'refresh_clicked',
+  PURGE_CLICKED = 'purge_clicked',
+  CONFIGURE_CLICKED = 'configure_clicked',
+}
+
 // Utility function to normalize names for event properties
 function normalizeEventName(name: string): string {
   return name
@@ -28,7 +42,7 @@ export function useInteractionTracker() {
   // Check interaction tracking
   const trackCheckInteraction = useCallback(
     (
-      interactionType: 'resolution_clicked' | 'refresh_clicked' | 'silence_clicked' | 'aisuggestion_clicked',
+      interactionType: CheckInteractionType,
       checkType: string,
       stepID: string,
       otherProperties?: Record<string, any>
@@ -45,7 +59,7 @@ export function useInteractionTracker() {
 
   // Global actions tracking
   const trackGlobalAction = useCallback(
-    (actionType: 'refresh_clicked' | 'purge_clicked' | 'configure_clicked') => {
+    (actionType: GlobalActionType) => {
       report(`grafana_plugin_advisor_global_actions_interaction`, {
         action_type: actionType,
       });

--- a/src/api/useInteractionTracker.ts
+++ b/src/api/useInteractionTracker.ts
@@ -1,0 +1,58 @@
+import { usePluginInteractionReporter } from '@grafana/runtime';
+import { useCallback } from 'react';
+
+// Utility function to normalize names for event properties
+function normalizeEventName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '');
+}
+
+// Custom hook for tracking user interactions
+export function useInteractionTracker() {
+  const report = usePluginInteractionReporter();
+
+  // Group toggle tracking
+  const trackGroupToggle = useCallback(
+    (groupName: string) => {
+      const normalizedGroupName = normalizeEventName(groupName);
+      report('grafana_plugin_advisor_group_toggled', {
+        group: normalizedGroupName,
+      });
+    },
+    [report]
+  );
+
+  // Check interaction tracking
+  const trackCheckInteraction = useCallback(
+    (
+      interactionType: 'resolution_clicked' | 'refresh_clicked' | 'silence_clicked' | 'aisuggestion_clicked',
+      checkType: string,
+      stepID: string
+    ) => {
+      report(`grafana_plugin_advisor_check_interaction`, {
+        interaction_type: interactionType,
+        check_type: checkType,
+        step_id: stepID,
+      });
+    },
+    [report]
+  );
+
+  // Global actions tracking
+  const trackGlobalAction = useCallback(
+    (actionType: 'refresh_clicked' | 'purge_clicked' | 'configure_clicked') => {
+      report(`grafana_plugin_advisor_global_actions_interaction`, {
+        action_type: actionType,
+      });
+    },
+    [report]
+  );
+
+  return {
+    trackGroupToggle,
+    trackCheckInteraction,
+    trackGlobalAction,
+  };
+}

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -6,6 +6,7 @@ import { css } from '@emotion/css';
 import { useDeleteChecks, useCreateChecks } from 'api/api';
 import { CheckStatus } from 'types';
 import ChecksStatus from './ChecksStatus';
+import { useInteractionTracker } from '../../api/useInteractionTracker';
 
 interface ActionsProps {
   isCompleted: boolean;
@@ -16,8 +17,25 @@ export default function Actions({ isCompleted, checkStatuses }: ActionsProps) {
   const { createChecks, createCheckState } = useCreateChecks();
   const { deleteChecks, deleteChecksState } = useDeleteChecks();
   const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
+  const { trackGlobalAction } = useInteractionTracker();
 
   const styles = useStyles2(getStyles);
+
+  const handleRefreshClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    createChecks();
+
+    // Track global refresh interaction
+    trackGlobalAction('refresh_clicked');
+  };
+
+  const handlePurgeClick = () => {
+    deleteChecks();
+    setConfirmDeleteModalOpen(false);
+
+    // Track global purge interaction
+    trackGlobalAction('purge_clicked');
+  };
 
   return (
     <div className={styles.actionsContainer}>
@@ -28,18 +46,12 @@ export default function Actions({ isCompleted, checkStatuses }: ActionsProps) {
             title="Delete reports?"
             body="Grafana keeps a history of reports, this action will delete all of them. It is not reversible."
             confirmText="Confirm"
-            onConfirm={() => {
-              deleteChecks();
-              setConfirmDeleteModalOpen(false);
-            }}
+            onConfirm={handlePurgeClick}
             onDismiss={() => setConfirmDeleteModalOpen(false)}
           />
 
           <Button
-            onClick={(e) => {
-              e.preventDefault();
-              createChecks();
-            }}
+            onClick={handleRefreshClick}
             disabled={!isCompleted}
             variant="secondary"
             icon={isCompleted ? 'sync' : 'spinner'}

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -6,7 +6,7 @@ import { css } from '@emotion/css';
 import { useDeleteChecks, useCreateChecks } from 'api/api';
 import { CheckStatus } from 'types';
 import ChecksStatus from './ChecksStatus';
-import { useInteractionTracker } from '../../api/useInteractionTracker';
+import { useInteractionTracker, GlobalActionType } from '../../api/useInteractionTracker';
 
 interface ActionsProps {
   isCompleted: boolean;
@@ -21,16 +21,15 @@ export default function Actions({ isCompleted, checkStatuses }: ActionsProps) {
 
   const styles = useStyles2(getStyles);
 
-  const handleRefreshClick = (e: React.MouseEvent) => {
-    e.preventDefault();
+  const handleRefreshClick = () => {
     createChecks();
-    trackGlobalAction('refresh_clicked');
+    trackGlobalAction(GlobalActionType.REFRESH_CLICKED);
   };
 
   const handlePurgeClick = () => {
     deleteChecks();
     setConfirmDeleteModalOpen(false);
-    trackGlobalAction('purge_clicked');
+    trackGlobalAction(GlobalActionType.PURGE_CLICKED);
   };
 
   return (

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -24,16 +24,12 @@ export default function Actions({ isCompleted, checkStatuses }: ActionsProps) {
   const handleRefreshClick = (e: React.MouseEvent) => {
     e.preventDefault();
     createChecks();
-
-    // Track global refresh interaction
     trackGlobalAction('refresh_clicked');
   };
 
   const handlePurgeClick = () => {
     deleteChecks();
     setConfirmDeleteModalOpen(false);
-
-    // Track global purge interaction
     trackGlobalAction('purge_clicked');
   };
 

--- a/src/components/CheckDrillDown/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown/CheckDrillDown.tsx
@@ -54,7 +54,7 @@ export default function CheckDrillDown({
       [stepId]: !isOpen[stepId],
     };
     setIsOpen(newState);
-    trackGroupToggle(stepId);
+    trackGroupToggle(stepId, newState[stepId]);
 
     // Update URL with open steps
     const openSteps = Object.entries(newState)
@@ -91,7 +91,17 @@ export default function CheckDrillDown({
                         {step.name} failed for {issues.length} {check.typeName || check.type}
                         {issues.length > 1 ? 's' : ''}.
                       </div>
-                      <div className={styles.resolution} dangerouslySetInnerHTML={{ __html: step.resolution }}></div>
+                      <div
+                        className={styles.resolution}
+                        dangerouslySetInnerHTML={{ __html: step.resolution }}
+                        onClick={(e) => {
+                          const target = e.target as HTMLElement;
+                          if (target.closest('a')) {
+                            // Avoid expanding/collapsing the section when clicking on a link
+                            e.stopPropagation();
+                          }
+                        }}
+                      ></div>
                     </div>
                   }
                   isOpen={isOpen[step.stepID] ?? false}

--- a/src/components/CheckDrillDown/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown/CheckDrillDown.tsx
@@ -71,6 +71,13 @@ export default function CheckDrillDown({
     navigate({ search: params.toString() }, { replace: true });
   };
 
+  const avoidLinkPropagation = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('a')) {
+      e.stopPropagation();
+    }
+  };
+
   return (
     <div className={styles.container}>
       {Object.values(checkSummary.checks).map((check) => {
@@ -94,13 +101,7 @@ export default function CheckDrillDown({
                       <div
                         className={styles.resolution}
                         dangerouslySetInnerHTML={{ __html: step.resolution }}
-                        onClick={(e) => {
-                          const target = e.target as HTMLElement;
-                          if (target.closest('a')) {
-                            // Avoid expanding/collapsing the section when clicking on a link
-                            e.stopPropagation();
-                          }
-                        }}
+                        onClick={avoidLinkPropagation}
                       ></div>
                     </div>
                   }

--- a/src/components/CheckDrillDown/CheckDrillDown.tsx
+++ b/src/components/CheckDrillDown/CheckDrillDown.tsx
@@ -5,6 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { type CheckSummary as CheckSummaryType } from 'types';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { IssueDescription } from './IssueDescription';
+import { useInteractionTracker } from '../../api/useInteractionTracker';
 
 export interface CheckDrillDownProps {
   checkSummary: CheckSummaryType;
@@ -27,6 +28,7 @@ export default function CheckDrillDown({
   const navigate = useNavigate();
   const scrollToRef = useRef<HTMLDivElement>(null);
   const [scrollToStep, setScrollToStep] = useState<string | null>(null);
+  const { trackGroupToggle } = useInteractionTracker();
 
   useEffect(() => {
     // Restore state from URL
@@ -52,6 +54,7 @@ export default function CheckDrillDown({
       [stepId]: !isOpen[stepId],
     };
     setIsOpen(newState);
+    trackGroupToggle(stepId);
 
     // Update URL with open steps
     const openSteps = Object.entries(newState)
@@ -105,6 +108,7 @@ export default function CheckDrillDown({
                           canRetry={check.canRetry}
                           isCompleted={isCompleted}
                           checkName={check.name}
+                          checkType={check.type}
                           itemID={issue.itemID}
                           stepID={step.stepID}
                           links={issue.links}

--- a/src/components/CheckDrillDown/IssueDescription.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.tsx
@@ -61,7 +61,9 @@ export function IssueDescription({
 
   const handleSilenceClick = () => {
     onHideIssue(!isHidden);
-    trackCheckInteraction('silence_clicked', checkType, stepID);
+    trackCheckInteraction('silence_clicked', checkType, stepID, {
+      silenced: isHidden,
+    });
   };
 
   const handleRetryClick = () => {

--- a/src/components/CheckSummary.tsx
+++ b/src/components/CheckSummary.tsx
@@ -34,7 +34,7 @@ export function CheckSummary({ checkSummary, retryCheck, isCompleted, showHidden
 
   const handleToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);
-    trackGroupToggle(checkSummary.severity);
+    trackGroupToggle(checkSummary.severity, isOpen);
 
     // Update URL with summary state
     const params = new URLSearchParams(location.search);

--- a/src/components/CheckSummary.tsx
+++ b/src/components/CheckSummary.tsx
@@ -6,6 +6,7 @@ import { Severity, type CheckSummary as CheckSummaryType } from 'types';
 import { CheckSummaryTitle } from './CheckSummaryTitle';
 import CheckDrillDown from './CheckDrillDown/CheckDrillDown';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useInteractionTracker } from '../api/useInteractionTracker';
 
 interface Props {
   checkSummary: CheckSummaryType;
@@ -22,6 +23,7 @@ export function CheckSummary({ checkSummary, retryCheck, isCompleted, showHidden
   const location = useLocation();
   const navigate = useNavigate();
   const isSummaryOpenParam = 'summaryOpen' + checkSummary.severity;
+  const { trackGroupToggle } = useInteractionTracker();
 
   useEffect(() => {
     // Restore state from URL
@@ -32,6 +34,9 @@ export function CheckSummary({ checkSummary, retryCheck, isCompleted, showHidden
 
   const handleToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);
+
+    // Track group toggle interaction
+    trackGroupToggle(checkSummary.severity);
 
     // Update URL with summary state
     const params = new URLSearchParams(location.search);

--- a/src/components/CheckSummary.tsx
+++ b/src/components/CheckSummary.tsx
@@ -34,8 +34,6 @@ export function CheckSummary({ checkSummary, retryCheck, isCompleted, showHidden
 
   const handleToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);
-
-    // Track group toggle interaction
     trackGroupToggle(checkSummary.severity);
 
     // Update URL with summary state

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -17,7 +17,6 @@ export function MoreInfo({ checkSummaries, showHiddenIssues, setShowHiddenIssues
   const { trackGlobalAction } = useInteractionTracker();
 
   const handleConfigureClick = () => {
-    // Track global configure interaction
     trackGlobalAction('configure_clicked');
   };
 

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Collapse, LinkButton, Switch, Field } from '@grafana/ui';
 import { type CheckSummaries } from 'types';
+import { useInteractionTracker } from '../api/useInteractionTracker';
 
 interface Props {
   checkSummaries: CheckSummaries;
@@ -13,6 +14,12 @@ interface Props {
 export function MoreInfo({ checkSummaries, showHiddenIssues, setShowHiddenIssues }: Props) {
   const [isOpen, setIsOpen] = React.useState(false);
   const styles = useStyles2(getStyles);
+  const { trackGlobalAction } = useInteractionTracker();
+
+  const handleConfigureClick = () => {
+    // Track global configure interaction
+    trackGlobalAction('configure_clicked');
+  };
 
   return (
     <Collapse
@@ -31,6 +38,7 @@ export function MoreInfo({ checkSummaries, showHiddenIssues, setShowHiddenIssues
             tooltip="Configure advisor steps"
             className={styles.configButton}
             href="/plugins/grafana-advisor-app?page=configuration"
+            onClick={handleConfigureClick}
           />
         </div>
       }

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -14,16 +14,21 @@ interface Props {
 export function MoreInfo({ checkSummaries, showHiddenIssues, setShowHiddenIssues }: Props) {
   const [isOpen, setIsOpen] = React.useState(false);
   const styles = useStyles2(getStyles);
-  const { trackGlobalAction } = useInteractionTracker();
+  const { trackGlobalAction, trackGroupToggle } = useInteractionTracker();
 
   const handleConfigureClick = () => {
     trackGlobalAction('configure_clicked');
   };
 
+  const handleToggle = (isOpen: boolean) => {
+    setIsOpen(isOpen);
+    trackGroupToggle('more_info', isOpen);
+  };
+
   return (
     <Collapse
       isOpen={isOpen}
-      onToggle={() => setIsOpen(!isOpen)}
+      onToggle={handleToggle}
       collapsible={true}
       label={
         <div className={styles.labelContainer}>

--- a/src/components/MoreInfo.tsx
+++ b/src/components/MoreInfo.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Collapse, LinkButton, Switch, Field } from '@grafana/ui';
 import { type CheckSummaries } from 'types';
-import { useInteractionTracker } from '../api/useInteractionTracker';
+import { useInteractionTracker, GlobalActionType } from '../api/useInteractionTracker';
 
 interface Props {
   checkSummaries: CheckSummaries;
@@ -16,9 +16,10 @@ export function MoreInfo({ checkSummaries, showHiddenIssues, setShowHiddenIssues
   const styles = useStyles2(getStyles);
   const { trackGlobalAction, trackGroupToggle } = useInteractionTracker();
 
-  const handleConfigureClick = () => {
-    trackGlobalAction('configure_clicked');
-  };
+  const handleConfigureClick = useCallback(() => {
+    trackGlobalAction(GlobalActionType.CONFIGURE_CLICKED);
+    trackGroupToggle('more_info', true);
+  }, [trackGlobalAction, trackGroupToggle]);
 
   const handleToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -7,6 +7,7 @@ import { renderWithRouter } from 'components/test/utils';
 // Mock PluginPage to render its actions prop
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
+  usePluginInteractionReporter: jest.fn(() => jest.fn()),
   PluginPage: ({ actions, children }: { actions: React.ReactNode; children: React.ReactNode }) => (
     <div>
       <div data-testid="plugin-actions">{actions}</div>


### PR DESCRIPTION
Add report interaction for the following events:

 - Toggle a group (e.g. "high severity" section or a specific check). 
 - Interaction with a check. Report the interaction type (e.g. `refresh_clicked`), the check type (e.g. `datasource`) and the step ID (e.g. `health_check`).
 - Global actions (e.g. refresh or delete the report).
 
 Fixes https://github.com/grafana/grafana-community-team/issues/484