### PR TITLE
Display partial results

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -120,7 +120,7 @@ describe('API Hooks', () => {
       expect(result.current.checks).toEqual([]);
     });
 
-    it('returns only processed checks', () => {
+    it('returns unprocessed checks', () => {
       const mockChecks = {
         items: [
           {
@@ -152,7 +152,7 @@ describe('API Hooks', () => {
 
       const { result } = renderHook(() => useLastChecks());
       expect(result.current.checks).toHaveLength(1);
-      expect(result.current.checks[0].metadata.name).toBe('check1');
+      expect(result.current.checks[0].metadata.name).toBe('check2');
     });
 
     it('returns only the latest check for each type', () => {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -242,7 +242,7 @@ export function useLastChecks() {
     for (const check of data.items) {
       const type = check.metadata.labels?.[CHECK_TYPE_LABEL];
 
-      if (!type || !check.metadata.creationTimestamp || !check.metadata.annotations?.[STATUS_ANNOTATION]) {
+      if (!type || !check.metadata.creationTimestamp) {
         continue;
       }
 

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -267,4 +267,31 @@ describe('Home', () => {
       expect(screen.queryByText(/last checked:/i)).not.toBeInTheDocument();
     });
   });
+
+  it('shows progress warning when checks are incomplete', async () => {
+    mockUseCompletedChecks.mockReturnValue({
+      isCompleted: false,
+      isLoading: false,
+      checkStatuses: [],
+    });
+
+    renderWithRouter(<Home />);
+    await waitFor(() => {
+      expect(screen.getByText(/report in progress/i)).toBeInTheDocument();
+      expect(screen.getByText(/results may change as checks complete/i)).toBeInTheDocument();
+    });
+  });
+
+  it('hides progress warning when checks are completed', async () => {
+    mockUseCompletedChecks.mockReturnValue({
+      isCompleted: true,
+      isLoading: false,
+      checkStatuses: [],
+    });
+
+    renderWithRouter(<Home />);
+    await waitFor(() => {
+      expect(screen.queryByText(/report in progress/i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,10 +19,10 @@ export default function Home() {
   const { retryCheck } = useRetryCheck();
 
   useEffect(() => {
-    if (!isLoading && !isError && isCompleted) {
+    if (!isLoading && !isError) {
       const isEmptyTemp = summaries.high.created.getTime() === 0;
       setIsEmpty(isEmptyTemp);
-      if (!isEmptyTemp) {
+      if (!isEmptyTemp && isCompleted) {
         const highIssueCount = Object.values(summaries.high.checks).reduce((acc, check) => acc + check.issueCount, 0);
         const lowIssueCount = Object.values(summaries.low.checks).reduce((acc, check) => acc + check.issueCount, 0);
         setIsHealthy(highIssueCount + lowIssueCount === 0);
@@ -89,6 +89,14 @@ export default function Home() {
         {/* Checks */}
         {!isLoading && !isError && summaries && !isEmpty && (
           <>
+            {/* Warning for incomplete report */}
+            {!isCompleted && (
+              <div className={styles.incompleteWarning}>
+                <Icon name="hourglass" />
+                Report in progress - <span className={styles.warningText}>results may change as checks complete</span>
+              </div>
+            )}
+
             {/* Check summaries */}
             <div className={styles.checksSummaries}>
               <Stack direction="column">
@@ -157,5 +165,18 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   error: css({
     marginTop: theme.spacing(2),
+  }),
+  incompleteWarning: css({
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    color: theme.colors.warning.text,
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontStyle: 'italic',
+  }),
+  warningText: css({
+    color: theme.colors.text.primary,
   }),
 });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -93,7 +93,8 @@ export default function Home() {
             {!isCompleted && (
               <div className={styles.incompleteWarning}>
                 <Icon name="hourglass" />
-                Report in progress - <span className={styles.warningText}>results may change as checks complete</span>
+                Report in progress -
+                <span className={styles.incompleteInfo}> results may change as checks complete</span>
               </div>
             )}
 
@@ -176,7 +177,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     fontStyle: 'italic',
   }),
-  warningText: css({
+  incompleteInfo: css({
     color: theme.colors.text.primary,
   }),
 });


### PR DESCRIPTION
Feedback from @sympatheticmoose. It may be useful to get partial results while checks are running (usually the data sources check takes longer). This PR adds support for that, plus a message saying that results will change:


https://github.com/user-attachments/assets/05a85a78-d826-47a8-b65d-629e6267764c

