### PR TITLE
Increase the limit when listing checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advisor",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advisor",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -30,6 +30,7 @@ export const advisorAPIv0alpha1 = generatedAPI.enhanceEndpoints({
   },
 });
 export const {
+  useLazyGetCheckQuery,
   useGetCheckQuery,
   useListCheckQuery,
   useCreateCheckMutation,

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -295,4 +295,20 @@ describe('Home', () => {
       expect(screen.queryByText(/report in progress/i)).not.toBeInTheDocument();
     });
   });
+
+  it('shows partial results warning when there are too many reports', async () => {
+    mockUseCheckSummaries.mockReturnValue({
+      summaries: defaultSummaries,
+      isLoading: false,
+      isError: false,
+      error: undefined,
+      partialResults: true,
+    });
+
+    renderWithRouter(<Home />);
+    await waitFor(() => {
+      expect(screen.getByText(/partial results/i)).toBeInTheDocument();
+      expect(screen.getByText(/found too many reports to process/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,8 +11,16 @@ import { formatDate } from 'utils';
 
 export default function Home() {
   const styles = useStyles2(getStyles);
-  const { summaries, isLoading, isError, error, showHiddenIssues, setShowHiddenIssues, handleHideIssue } =
-    useCheckSummaries();
+  const {
+    summaries,
+    isLoading,
+    isError,
+    error,
+    showHiddenIssues,
+    setShowHiddenIssues,
+    handleHideIssue,
+    partialResults,
+  } = useCheckSummaries();
   const [isEmpty, setIsEmpty] = useState(false);
   const [isHealthy, setIsHealthy] = useState(false);
   const { isCompleted, checkStatuses } = useCompletedChecks();
@@ -67,6 +75,13 @@ export default function Home() {
           <div className={styles.loading}>
             <LoadingPlaceholder text="Loading..." />
           </div>
+        )}
+
+        {/* Partial results */}
+        {partialResults && (
+          <Alert title="Partial results" className={styles.error} severity="warning">
+            Found too many reports to process. Please delete them and refresh.
+          </Alert>
         )}
 
         {/* Error */}


### PR DESCRIPTION
The default limit when listing resources is 50. If in a system there are more saved checks than that, the UI shows a partial result (the `continue` token gets ignored).

I tried to do proper pagination and request all pages but due to the auto generated RTK client and its cache logic, it got too complicated (see my attempt in https://github.com/grafana/grafana-advisor-app/pull/81/).

Rather than that, I have increased the API limit to 1000, so in normal conditions, all reports will be returned with a single requests (even more unlikely after https://github.com/grafana/grafana/pull/108583).

In case that limit is reached, an error message is rendered:

<img width="963" height="476" alt="Screenshot 2025-07-25 at 12 34 37" src="https://github.com/user-attachments/assets/30c98f29-8fcb-448b-bb89-84978109cc4f" />
