### PR TITLE
Add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,74 +2,60 @@
     "ignorePresets": [
         "github>grafana/grafana-renovate-config//presets/automerge"
     ],
-    "schedule": [
-        "before 6am on the first day of the month"
-    ],
+    "schedule": ["before 6am on the first day of the month"],
     "packageRules": [
-        {
-            "groupName": "Grafana packages",
-            "matchPackagePatterns": [
-                "^@grafana/"
-            ]
-        },
-        {
-            "groupName": "React ecosystem",
-            "matchPackagePatterns": [
-                "^react$",
-                "^react-",
-                "^@types/react"
-            ],
-            "minimumReleaseAge": "14 days"
-        },
-        {
-            "groupName": "Testing tools",
-            "matchPackagePatterns": [
-                "^jest$",
-                "^jest-",
-                "^@jest/",
-                "^@testing-library/",
-                "^@playwright/",
-                "^playwright$",
-                "^@types/jest",
-                "^@types/testing-library"
-            ],
-            "minimumReleaseAge": "14 days"
-        },
-        {
-            "groupName": "Build tools",
-            "matchPackagePatterns": [
-                "^webpack$",
-                "^webpack-",
-                "-webpack-plugin$",
-                "-loader$",
-                "^@swc/",
-                "^swc-",
-                "^terser-",
-                "^copy-webpack-plugin$",
-                "^fork-ts-checker-webpack-plugin$",
-                "^replace-in-file-webpack-plugin$",
-                "^ts-node$"
-            ],
-            "minimumReleaseAge": "14 days"
-        },
-        {
-            "groupName": "TypeScript and linting",
-            "matchPackagePatterns": [
-                "^typescript$",
-                "^@typescript-eslint/",
-                "^eslint$",
-                "^eslint-",
-                "^@stylistic/",
-                "^prettier$",
-                "^@types/eslint"
-            ],
-            "minimumReleaseAge": "14 days"
-        }
+      {"groupName": "Grafana packages", "matchPackageNames": ["/^@grafana//"]},
+      {
+        "groupName": "React ecosystem",
+        "minimumReleaseAge": "14 days",
+        "matchPackageNames": ["/^react$/", "/^react-/", "/^@types/react/"]
+      },
+      {
+        "groupName": "Testing tools",
+        "minimumReleaseAge": "14 days",
+        "matchPackageNames": [
+          "/^jest$/",
+          "/^jest-/",
+          "/^@jest//",
+          "/^@testing-library//",
+          "/^@playwright//",
+          "/^playwright$/",
+          "/^@types/jest/",
+          "/^@types/testing-library/"
+        ]
+      },
+      {
+        "groupName": "Build tools",
+        "minimumReleaseAge": "14 days",
+        "matchPackageNames": [
+          "/^webpack$/",
+          "/^webpack-/",
+          "/-webpack-plugin$/",
+          "/-loader$/",
+          "/^@swc//",
+          "/^swc-/",
+          "/^terser-/",
+          "/^copy-webpack-plugin$/",
+          "/^fork-ts-checker-webpack-plugin$/",
+          "/^replace-in-file-webpack-plugin$/",
+          "/^ts-node$/"
+        ]
+      },
+      {
+        "groupName": "TypeScript and linting",
+        "minimumReleaseAge": "14 days",
+        "matchPackageNames": [
+          "/^typescript$/",
+          "/^@typescript-eslint//",
+          "/^eslint$/",
+          "/^eslint-/",
+          "/^@stylistic//",
+          "/^prettier$/",
+          "/^@types/eslint/"
+        ]
+      }
     ],
-    "github-actions": {
-        "enabled": true,
-        "groupName": "GitHub Actions"
-    },
+    "github-actions": {"enabled": true, "groupName": "GitHub Actions"},
     "commitMessagePrefix": "chore(deps): ",
     "branchPrefix": "renovate/"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,71 @@
+{
+    "ignorePresets": [
+        "github>grafana/grafana-renovate-config//presets/automerge"
+    ],
+    "schedule": [
+        "before 6am on the first day of the month"
+    ],
+    "packageRules": [
+        {
+            "groupName": "Grafana packages",
+            "matchPackagePatterns": [
+                "^@grafana/"
+            ]
+        },
+        {
+            "groupName": "React ecosystem",
+            "matchPackagePatterns": [
+                "^react$",
+                "^react-",
+                "^@types/react"
+            ]
+        },
+        {
+            "groupName": "Testing tools",
+            "matchPackagePatterns": [
+                "^jest$",
+                "^jest-",
+                "^@jest/",
+                "^@testing-library/",
+                "^@playwright/",
+                "^playwright$",
+                "^@types/jest",
+                "^@types/testing-library"
+            ]
+        },
+        {
+            "groupName": "Build tools",
+            "matchPackagePatterns": [
+                "^webpack$",
+                "^webpack-",
+                "-webpack-plugin$",
+                "-loader$",
+                "^@swc/",
+                "^swc-",
+                "^terser-",
+                "^copy-webpack-plugin$",
+                "^fork-ts-checker-webpack-plugin$",
+                "^replace-in-file-webpack-plugin$",
+                "^ts-node$"
+            ]
+        },
+        {
+            "groupName": "TypeScript and linting",
+            "matchPackagePatterns": [
+                "^typescript$",
+                "^@typescript-eslint/",
+                "^eslint$",
+                "^eslint-",
+                "^@stylistic/",
+                "^prettier$",
+                "^@types/eslint"
+            ]
+        }
+    ],
+    "github-actions": {
+        "enabled": true,
+        "groupName": "GitHub Actions"
+    },
+    "commitMessagePrefix": "chore(deps): ",
+    "branchPrefix": "renovate/"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     ],
     "schedule": ["before 6am on the first day of the month"],
     "packageRules": [
-      {"groupName": "Grafana packages", "matchPackageNames": ["/^@grafana//"]},
+      {"groupName": "Grafana packages", "matchPackageNames": ["/^@grafana//"], "enabled": false},
       {
         "groupName": "React ecosystem",
         "minimumReleaseAge": "14 days",

--- a/renovate.json
+++ b/renovate.json
@@ -7,12 +7,10 @@
       {"groupName": "Grafana packages", "matchPackageNames": ["/^@grafana//"], "matchDepTypes": ["dependencies"], "enabled": false},
       {
         "groupName": "React ecosystem",
-        "minimumReleaseAge": "14 days",
         "matchPackageNames": ["/^react$/", "/^react-/", "/^@types/react/"]
       },
       {
         "groupName": "Testing tools",
-        "minimumReleaseAge": "14 days",
         "matchPackageNames": [
           "/^jest$/",
           "/^jest-/",
@@ -26,7 +24,6 @@
       },
       {
         "groupName": "Build tools",
-        "minimumReleaseAge": "14 days",
         "matchPackageNames": [
           "/^webpack$/",
           "/^webpack-/",
@@ -43,7 +40,6 @@
       },
       {
         "groupName": "TypeScript and linting",
-        "minimumReleaseAge": "14 days",
         "matchPackageNames": [
           "/^typescript$/",
           "/^@typescript-eslint//",
@@ -57,5 +53,6 @@
     ],
     "github-actions": {"enabled": true, "groupName": "GitHub Actions"},
     "commitMessagePrefix": "chore(deps): ",
+    "minimumReleaseAge":"14 days",
     "branchPrefix": "renovate/"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     ],
     "schedule": ["before 6am on the first day of the month"],
     "packageRules": [
-      {"groupName": "Grafana packages", "matchPackageNames": ["/^@grafana//"], "enabled": false},
+      {"groupName": "Grafana packages", "matchPackageNames": ["/^@grafana//"], "matchDepTypes": ["dependencies"], "enabled": false},
       {
         "groupName": "React ecosystem",
         "minimumReleaseAge": "14 days",

--- a/renovate.json
+++ b/renovate.json
@@ -1,58 +1,62 @@
 {
-    "ignorePresets": [
-        "github>grafana/grafana-renovate-config//presets/automerge"
-    ],
-    "schedule": ["before 6am on the first day of the month"],
-    "packageRules": [
-      {"groupName": "Grafana packages", "matchPackageNames": ["/^@grafana//"], "matchDepTypes": ["dependencies"], "enabled": false},
-      {
-        "groupName": "React ecosystem",
-        "matchPackageNames": ["/^react$/", "/^react-/", "/^@types/react/"]
-      },
-      {
-        "groupName": "Testing tools",
-        "matchPackageNames": [
-          "/^jest$/",
-          "/^jest-/",
-          "/^@jest//",
-          "/^@testing-library//",
-          "/^@playwright//",
-          "/^playwright$/",
-          "/^@types/jest/",
-          "/^@types/testing-library/"
-        ]
-      },
-      {
-        "groupName": "Build tools",
-        "matchPackageNames": [
-          "/^webpack$/",
-          "/^webpack-/",
-          "/-webpack-plugin$/",
-          "/-loader$/",
-          "/^@swc//",
-          "/^swc-/",
-          "/^terser-/",
-          "/^copy-webpack-plugin$/",
-          "/^fork-ts-checker-webpack-plugin$/",
-          "/^replace-in-file-webpack-plugin$/",
-          "/^ts-node$/"
-        ]
-      },
-      {
-        "groupName": "TypeScript and linting",
-        "matchPackageNames": [
-          "/^typescript$/",
-          "/^@typescript-eslint//",
-          "/^eslint$/",
-          "/^eslint-/",
-          "/^@stylistic//",
-          "/^prettier$/",
-          "/^@types/eslint/"
-        ]
-      }
-    ],
-    "github-actions": {"enabled": true, "groupName": "GitHub Actions"},
-    "commitMessagePrefix": "chore(deps): ",
-    "minimumReleaseAge":"14 days",
-    "branchPrefix": "renovate/"
+  "ignorePresets": ["github>grafana/grafana-renovate-config//presets/automerge"],
+  "schedule": ["before 6am on the first day of the month"],
+  "packageRules": [
+    {
+      "groupName": "Grafana packages",
+      "matchPackageNames": ["/^@grafana//"],
+      "matchDepTypes": ["dependencies"],
+      "enabled": false
+    },
+    {
+      "groupName": "React ecosystem",
+      "matchPackageNames": ["/^react$/", "/^react-/", "/^@types/react/"]
+    },
+    {
+      "groupName": "Testing tools",
+      "matchPackageNames": [
+        "/^jest$/",
+        "/^jest-/",
+        "/^@jest//",
+        "/^@testing-library//",
+        "/^@playwright//",
+        "/^playwright$/",
+        "/^@types/jest/",
+        "/^@types/testing-library/"
+      ]
+    },
+    {
+      "groupName": "Build tools",
+      "matchPackageNames": [
+        "/^webpack$/",
+        "/^webpack-/",
+        "/-webpack-plugin$/",
+        "/-loader$/",
+        "/^@swc//",
+        "/^swc-/",
+        "/^terser-/",
+        "/^copy-webpack-plugin$/",
+        "/^fork-ts-checker-webpack-plugin$/",
+        "/^replace-in-file-webpack-plugin$/",
+        "/^ts-node$/"
+      ]
+    },
+    {
+      "groupName": "TypeScript and linting",
+      "matchPackageNames": [
+        "/^typescript$/",
+        "/^@typescript-eslint//",
+        "/^eslint$/",
+        "/^eslint-/",
+        "/^@stylistic//",
+        "/^prettier$/",
+        "/^@types/eslint/"
+      ]
+    }
+  ],
+  "github-actions": { "enabled": true, "groupName": "GitHub Actions" },
+  "commitMessagePrefix": "chore(deps): ",
+  "minimumReleaseAge": "14 days",
+  "rangeStrategy": "bump",
+  "branchPrefix": "renovate/"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,8 @@
                 "^react$",
                 "^react-",
                 "^@types/react"
-            ]
+            ],
+            "minimumReleaseAge": "14 days"
         },
         {
             "groupName": "Testing tools",
@@ -31,7 +32,8 @@
                 "^playwright$",
                 "^@types/jest",
                 "^@types/testing-library"
-            ]
+            ],
+            "minimumReleaseAge": "14 days"
         },
         {
             "groupName": "Build tools",
@@ -47,7 +49,8 @@
                 "^fork-ts-checker-webpack-plugin$",
                 "^replace-in-file-webpack-plugin$",
                 "^ts-node$"
-            ]
+            ],
+            "minimumReleaseAge": "14 days"
         },
         {
             "groupName": "TypeScript and linting",
@@ -59,7 +62,8 @@
                 "^@stylistic/",
                 "^prettier$",
                 "^@types/eslint"
-            ]
+            ],
+            "minimumReleaseAge": "14 days"
         }
     ],
     "github-actions": {


### PR DESCRIPTION
Not sure if config overrides in self hosted dependabot work the same way as defined in https://docs.renovatebot.com/getting-started/installing-onboarding/#reconfigure-via-pr

But let's see if it does. This config is trying to match [dependabot](https://github.com/grafana/grafana-advisor-app/blob/main/.github/dependabot.yml) and even without being merged it should already have an effect on how dependabot interacts with this repository because this branch should override the config

Testing:

```
npx --yes --package renovate -- renovate-config-validator
INFO: Config validated successfully
```