### PR TITLE
Fixes for retry button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advisor",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advisor",
-      "version": "0.0.11",
+      "version": "0.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -338,6 +338,7 @@ function useIncompleteChecks(names?: string[]) {
     return Array.from(checksByType.values())
       .filter((check) => (names ? names.includes(check.metadata.name ?? '') : true))
       .map((check): CheckStatus => {
+        // Use the creation timestamp or the last managed field timestamp
         let lastUpdate = check.metadata.creationTimestamp ? new Date(check.metadata.creationTimestamp) : new Date(0);
         for (const field of check.metadata.managedFields ?? []) {
           if (field.time && new Date(field.time) > lastUpdate) {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -337,17 +337,23 @@ function useIncompleteChecks(names?: string[]) {
     // Filter incomplete checks from the most recent ones
     return Array.from(checksByType.values())
       .filter((check) => (names ? names.includes(check.metadata.name ?? '') : true))
-      .map(
-        (check): CheckStatus => ({
+      .map((check): CheckStatus => {
+        let lastUpdate = check.metadata.creationTimestamp ? new Date(check.metadata.creationTimestamp) : new Date(0);
+        for (const field of check.metadata.managedFields ?? []) {
+          if (field.time && new Date(field.time) > lastUpdate) {
+            lastUpdate = new Date(field.time);
+          }
+        }
+        return {
           name: check.metadata.labels?.[CHECK_TYPE_LABEL] ?? '',
-          creationTimestamp: check.metadata.creationTimestamp ?? '',
+          lastUpdate: lastUpdate,
           incomplete:
             !check.metadata.annotations?.[STATUS_ANNOTATION] ||
             (check.metadata.annotations?.[RETRY_ANNOTATION] !== undefined &&
               check.metadata.annotations?.[STATUS_ANNOTATION] !== 'error'),
           hasError: check.metadata.annotations?.[STATUS_ANNOTATION] === 'error',
-        })
-      );
+        };
+      });
   }, [listChecksState.data, names]);
 
   // Update polling interval based on incomplete checks

--- a/src/components/Actions/CheckWarning.test.tsx
+++ b/src/components/Actions/CheckWarning.test.tsx
@@ -5,8 +5,8 @@ import CheckWarning from './CheckWarning';
 describe('CheckWarning', () => {
   it('renders warning message for checks older than 5 seconds', () => {
     const twentyMinutesAgo = new Date(Date.now() - 20 * 60 * 1000);
-    render(<CheckWarning checkCreated={twentyMinutesAgo} />);
+    render(<CheckWarning checkLastUpdate={twentyMinutesAgo} />);
 
-    expect(screen.getByText(/Check is taking longer than expected \(started 20 minutes ago\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Check is taking longer than expected \(updated 20 minutes ago\)/)).toBeInTheDocument();
   });
 });

--- a/src/components/Actions/CheckWarning.tsx
+++ b/src/components/Actions/CheckWarning.tsx
@@ -5,18 +5,18 @@ import { css } from '@emotion/css';
 import { formatDistanceToNow } from 'date-fns';
 
 interface CheckWarningProps {
-  checkCreated: Date;
+  checkLastUpdate: Date;
 }
 
-export default function CheckWarning({ checkCreated }: CheckWarningProps) {
+export default function CheckWarning({ checkLastUpdate }: CheckWarningProps) {
   const styles = useStyles2(getStyles);
 
   return (
     <div className={styles.warningContainer}>
       <Icon name="exclamation-triangle" className={styles.warningIcon} />
       <span className={styles.warningText}>
-        Check is taking longer than expected (started {formatDistanceToNow(checkCreated)} ago). Inspect server logs for
-        errors or delete and re-create the report to retry.
+        Check is taking longer than expected (updated {formatDistanceToNow(checkLastUpdate)} ago). Inspect server logs
+        for errors or delete and re-create the report to retry.
       </span>
     </div>
   );

--- a/src/components/Actions/ChecksStatus.test.tsx
+++ b/src/components/Actions/ChecksStatus.test.tsx
@@ -7,17 +7,17 @@ import { CheckStatus } from 'types';
 describe('RunningChecksStatus', () => {
   const user = userEvent.setup();
 
-  const oldDate = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+  const oldDate = new Date(Date.now() - 20 * 60 * 1000);
   const mockCheckStatuses: CheckStatus[] = [
     {
       name: 'datasource',
-      creationTimestamp: oldDate,
+      lastUpdate: oldDate,
       incomplete: true,
       hasError: false,
     },
     {
       name: 'plugin',
-      creationTimestamp: oldDate,
+      lastUpdate: oldDate,
       incomplete: false,
       hasError: false,
     },
@@ -29,7 +29,7 @@ describe('RunningChecksStatus', () => {
         checkStatuses={[
           {
             name: 'datasource',
-            creationTimestamp: new Date().toISOString(),
+            lastUpdate: new Date(),
             incomplete: false,
             hasError: false,
           },
@@ -50,7 +50,7 @@ describe('RunningChecksStatus', () => {
     const checkStatusesWithError: CheckStatus[] = [
       {
         name: 'datasource',
-        creationTimestamp: new Date().toISOString(),
+        lastUpdate: new Date(),
         incomplete: false,
         hasError: true,
       },
@@ -89,7 +89,7 @@ describe('RunningChecksStatus', () => {
     const checkStatusesWithError: CheckStatus[] = [
       {
         name: 'datasource',
-        creationTimestamp: new Date().toISOString(),
+        lastUpdate: new Date(),
         incomplete: false,
         hasError: true,
       },

--- a/src/components/Actions/ChecksStatus.tsx
+++ b/src/components/Actions/ChecksStatus.tsx
@@ -15,7 +15,7 @@ export default function ChecksStatus({ checkStatuses }: RunningChecksStatusProps
   const [isStatusExpanded, setIsStatusExpanded] = useState(false);
   const styles = useStyles2(getStyles);
   const hasError = checkStatuses.some((check) => check.hasError);
-  const hasOldChecks = checkStatuses.some(isOld);
+  const hasOldChecks = checkStatuses.some((check) => isOld(check) && check.incomplete);
   const allChecksCompleted = checkStatuses.every((check) => !check.incomplete);
 
   return (
@@ -38,8 +38,6 @@ export default function ChecksStatus({ checkStatuses }: RunningChecksStatusProps
             <div className={styles.checksHeader}>Check types</div>
             <div className={styles.checksContainer}>
               {checkStatuses.map((check, index) => {
-                const checkCreated = new Date(check.creationTimestamp);
-
                 return (
                   <div key={`${check.name}-${index}`} className={styles.checkItemWrapper}>
                     <div className={styles.checkItem}>
@@ -48,7 +46,7 @@ export default function ChecksStatus({ checkStatuses }: RunningChecksStatusProps
                       {!check.incomplete && !check.hasError && <Icon name="check" className={styles.completedIcon} />}
                       <span className={styles.checkName}>{check.name}</span>
                     </div>
-                    {check.incomplete && isOld(check) && <CheckWarning checkCreated={checkCreated} />}
+                    {check.incomplete && isOld(check) && <CheckWarning checkLastUpdate={check.lastUpdate} />}
                     {check.hasError && <CheckError />}
                   </div>
                 );

--- a/src/components/CheckDrillDown/IssueDescription.test.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.test.tsx
@@ -3,25 +3,12 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 import { IssueDescription } from './IssueDescription';
-import { useLLMSuggestion } from 'api/api';
 import { usePluginContext } from 'contexts/Context';
-import { useInteractionTracker } from '../../api/useInteractionTracker';
 
 // Mock dependencies
-jest.mock('api/api');
 jest.mock('contexts/Context');
-jest.mock('../../api/useInteractionTracker');
 
-const mockUseLLMSuggestion = useLLMSuggestion as jest.MockedFunction<typeof useLLMSuggestion>;
 const mockUsePluginContext = usePluginContext as jest.MockedFunction<typeof usePluginContext>;
-const mockUseInteractionTracker = useInteractionTracker as jest.MockedFunction<typeof useInteractionTracker>;
-
-// Mock LLMSuggestionContent component
-jest.mock('./LLMSuggestionContent', () => ({
-  LLMSuggestionContent: ({ isLoading, response }: { isLoading: boolean; response: string | null }) => (
-    <div data-testid="llm-suggestion-content">{isLoading ? 'Loading...' : response || 'No response'}</div>
-  ),
-}));
 
 const defaultProps = {
   item: 'Dashboard "Test Dashboard" has performance issues',
@@ -48,28 +35,13 @@ const renderWithRouter = (component: React.ReactElement) => {
 };
 
 describe('IssueDescription', () => {
-  const mockGetSuggestion = jest.fn();
-  const mockTrackCheckInteraction = jest.fn();
-
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers(); // Ensure real timers are used by default
 
-    mockUseLLMSuggestion.mockReturnValue({
-      getSuggestion: mockGetSuggestion,
-      response: null,
-      isLoading: false,
-    });
-
     mockUsePluginContext.mockReturnValue({
       isLLMEnabled: true,
       isLoading: false,
-    });
-
-    mockUseInteractionTracker.mockReturnValue({
-      trackCheckInteraction: mockTrackCheckInteraction,
-      trackGroupToggle: jest.fn(),
-      trackGlobalAction: jest.fn(),
     });
   });
 
@@ -86,148 +58,6 @@ describe('IssueDescription', () => {
     expect(screen.getByTitle('Retry check')).toBeInTheDocument();
     expect(screen.getByText('Fix this issue')).toBeInTheDocument();
     expect(screen.getByText('More info')).toBeInTheDocument();
-  });
-
-  it('triggers loading behavior when AI suggestion button is clicked multiple times', async () => {
-    const user = userEvent.setup();
-
-    // Mock the loading states for multiple calls
-    let callCount = 0;
-    mockUseLLMSuggestion.mockImplementation(() => {
-      callCount++;
-      return {
-        getSuggestion: mockGetSuggestion,
-        response: callCount === 1 ? null : 'AI suggestion response',
-        isLoading: callCount <= 2, // First two calls show loading
-      };
-    });
-
-    const { rerender } = renderWithRouter(<IssueDescription {...defaultProps} />);
-
-    const aiButton = screen.getByTitle('Generate AI suggestion');
-
-    // First click - should trigger getSuggestion and show loading
-    await user.click(aiButton);
-
-    expect(mockGetSuggestion).toHaveBeenCalledWith('check1', 'step1', 'item1');
-    expect(mockGetSuggestion).toHaveBeenCalledTimes(1);
-
-    // Simulate loading state
-    mockUseLLMSuggestion.mockReturnValue({
-      getSuggestion: mockGetSuggestion,
-      response: null,
-      isLoading: true,
-    });
-
-    rerender(
-      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-        <IssueDescription {...defaultProps} />
-      </BrowserRouter>
-    );
-
-    // Verify LLM section is open and shows loading
-    expect(screen.getByTestId('llm-suggestion-content')).toBeInTheDocument();
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
-
-    // Simulate completion of first call
-    mockUseLLMSuggestion.mockReturnValue({
-      getSuggestion: mockGetSuggestion,
-      response: 'First AI suggestion',
-      isLoading: false,
-    });
-
-    rerender(
-      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-        <IssueDescription {...defaultProps} />
-      </BrowserRouter>
-    );
-
-    expect(screen.getByText('First AI suggestion')).toBeInTheDocument();
-
-    // Reset mock call count for second test
-    mockGetSuggestion.mockClear();
-
-    // Click the AI button again (it should toggle closed first, then open again)
-    await user.click(aiButton); // This closes it
-    await user.click(aiButton); // This opens it and calls getSuggestion again
-
-    // Verify getSuggestion was called again with same parameters
-    expect(mockGetSuggestion).toHaveBeenCalledWith('check1', 'step1', 'item1');
-    expect(mockGetSuggestion).toHaveBeenCalledTimes(1); // Called once after clear
-
-    // Simulate loading state for second call
-    mockUseLLMSuggestion.mockReturnValue({
-      getSuggestion: mockGetSuggestion,
-      response: 'First AI suggestion',
-      isLoading: true,
-    });
-
-    rerender(
-      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-        <IssueDescription {...defaultProps} />
-      </BrowserRouter>
-    );
-
-    // Verify loading is shown again
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
-  });
-
-  it('shows AI suggestion when LLM section is open', async () => {
-    const user = userEvent.setup();
-
-    mockUseLLMSuggestion.mockReturnValue({
-      getSuggestion: mockGetSuggestion,
-      response: 'This is an AI-generated suggestion for your issue.',
-      isLoading: false,
-    });
-
-    renderWithRouter(<IssueDescription {...defaultProps} />);
-
-    const aiButton = screen.getByTitle('Generate AI suggestion');
-    await user.click(aiButton);
-
-    expect(screen.getByTestId('llm-suggestion-content')).toBeInTheDocument();
-    expect(screen.getByText('This is an AI-generated suggestion for your issue.')).toBeInTheDocument();
-  });
-
-  it('does not show AI button when LLM is disabled', () => {
-    mockUsePluginContext.mockReturnValue({
-      isLLMEnabled: false,
-      isLoading: false,
-    });
-
-    renderWithRouter(<IssueDescription {...defaultProps} />);
-
-    expect(screen.queryByTitle('Generate AI suggestion')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('llm-suggestion-content')).not.toBeInTheDocument();
-  });
-
-  it('calls getSuggestion only when opening LLM section', async () => {
-    const user = userEvent.setup();
-
-    renderWithRouter(<IssueDescription {...defaultProps} />);
-
-    const aiButton = screen.getByTitle('Generate AI suggestion');
-
-    // First click - opens section and calls getSuggestion
-    await user.click(aiButton);
-    expect(mockGetSuggestion).toHaveBeenCalledTimes(1);
-
-    // Second click - closes section, should not call getSuggestion again
-    await user.click(aiButton);
-    expect(mockGetSuggestion).toHaveBeenCalledTimes(1); // Still only 1 call
-    expect(screen.queryByTestId('llm-suggestion-content')).not.toBeInTheDocument();
-  });
-
-  it('tracks interaction when AI suggestion button is clicked', async () => {
-    const user = userEvent.setup();
-
-    renderWithRouter(<IssueDescription {...defaultProps} />);
-
-    const aiButton = screen.getByTitle('Generate AI suggestion');
-    await user.click(aiButton);
-
-    expect(mockTrackCheckInteraction).toHaveBeenCalledWith('aisuggestion_clicked', 'dashboard-performance', 'step1');
   });
 
   it('handles retry button click with local loading state', async () => {
@@ -247,7 +77,6 @@ describe('IssueDescription', () => {
     // After click, button should be disabled
     expect(retryButton).toBeDisabled();
     expect(mockOnRetryCheck).toHaveBeenCalledTimes(1);
-    expect(mockTrackCheckInteraction).toHaveBeenCalledWith('refresh_clicked', 'dashboard-performance', 'step1');
 
     // After timeout, button should be enabled again
     act(() => {
@@ -259,20 +88,5 @@ describe('IssueDescription', () => {
     });
 
     jest.useRealTimers();
-  });
-
-  it('handles hide/show issue button click', async () => {
-    const user = userEvent.setup();
-    const mockOnHideIssue = jest.fn();
-
-    renderWithRouter(<IssueDescription {...defaultProps} onHideIssue={mockOnHideIssue} />);
-
-    const hideButton = screen.getByTitle('Hide issue');
-    await user.click(hideButton);
-
-    expect(mockOnHideIssue).toHaveBeenCalledWith(true);
-    expect(mockTrackCheckInteraction).toHaveBeenCalledWith('silence_clicked', 'dashboard-performance', 'step1', {
-      silenced: true,
-    });
   });
 });

--- a/src/components/CheckDrillDown/IssueDescription.test.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.test.tsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import { IssueDescription } from './IssueDescription';
+import { useLLMSuggestion } from 'api/api';
+import { usePluginContext } from 'contexts/Context';
+import { useInteractionTracker } from '../../api/useInteractionTracker';
+
+// Mock dependencies
+jest.mock('api/api');
+jest.mock('contexts/Context');
+jest.mock('../../api/useInteractionTracker');
+
+const mockUseLLMSuggestion = useLLMSuggestion as jest.MockedFunction<typeof useLLMSuggestion>;
+const mockUsePluginContext = usePluginContext as jest.MockedFunction<typeof usePluginContext>;
+const mockUseInteractionTracker = useInteractionTracker as jest.MockedFunction<typeof useInteractionTracker>;
+
+// Mock LLMSuggestionContent component
+jest.mock('./LLMSuggestionContent', () => ({
+  LLMSuggestionContent: ({ isLoading, response }: { isLoading: boolean; response: string | null }) => (
+    <div data-testid="llm-suggestion-content">{isLoading ? 'Loading...' : response || 'No response'}</div>
+  ),
+}));
+
+const defaultProps = {
+  item: 'Dashboard "Test Dashboard" has performance issues',
+  isHidden: false,
+  isRetrying: false,
+  canRetry: true,
+  isCompleted: true,
+  checkType: 'dashboard-performance',
+  checkName: 'check1',
+  itemID: 'item1',
+  stepID: 'step1',
+  links: [
+    { url: 'https://example.com/fix', message: 'Fix this issue' },
+    { url: '/local/help', message: 'More info' },
+  ],
+  onHideIssue: jest.fn(),
+  onRetryCheck: jest.fn(),
+};
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(
+    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>{component}</BrowserRouter>
+  );
+};
+
+describe('IssueDescription', () => {
+  const mockGetSuggestion = jest.fn();
+  const mockTrackCheckInteraction = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers(); // Ensure real timers are used by default
+
+    mockUseLLMSuggestion.mockReturnValue({
+      getSuggestion: mockGetSuggestion,
+      response: null,
+      isLoading: false,
+    });
+
+    mockUsePluginContext.mockReturnValue({
+      isLLMEnabled: true,
+      isLoading: false,
+    });
+
+    mockUseInteractionTracker.mockReturnValue({
+      trackCheckInteraction: mockTrackCheckInteraction,
+      trackGroupToggle: jest.fn(),
+      trackGlobalAction: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers(); // Clean up any fake timers after each test
+  });
+
+  it('renders issue description with all buttons', () => {
+    renderWithRouter(<IssueDescription {...defaultProps} />);
+
+    expect(screen.getByText(defaultProps.item)).toBeInTheDocument();
+    expect(screen.getByTitle('Generate AI suggestion')).toBeInTheDocument();
+    expect(screen.getByTitle('Hide issue')).toBeInTheDocument();
+    expect(screen.getByTitle('Retry check')).toBeInTheDocument();
+    expect(screen.getByText('Fix this issue')).toBeInTheDocument();
+    expect(screen.getByText('More info')).toBeInTheDocument();
+  });
+
+  it('triggers loading behavior when AI suggestion button is clicked multiple times', async () => {
+    const user = userEvent.setup();
+
+    // Mock the loading states for multiple calls
+    let callCount = 0;
+    mockUseLLMSuggestion.mockImplementation(() => {
+      callCount++;
+      return {
+        getSuggestion: mockGetSuggestion,
+        response: callCount === 1 ? null : 'AI suggestion response',
+        isLoading: callCount <= 2, // First two calls show loading
+      };
+    });
+
+    const { rerender } = renderWithRouter(<IssueDescription {...defaultProps} />);
+
+    const aiButton = screen.getByTitle('Generate AI suggestion');
+
+    // First click - should trigger getSuggestion and show loading
+    await user.click(aiButton);
+
+    expect(mockGetSuggestion).toHaveBeenCalledWith('check1', 'step1', 'item1');
+    expect(mockGetSuggestion).toHaveBeenCalledTimes(1);
+
+    // Simulate loading state
+    mockUseLLMSuggestion.mockReturnValue({
+      getSuggestion: mockGetSuggestion,
+      response: null,
+      isLoading: true,
+    });
+
+    rerender(
+      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <IssueDescription {...defaultProps} />
+      </BrowserRouter>
+    );
+
+    // Verify LLM section is open and shows loading
+    expect(screen.getByTestId('llm-suggestion-content')).toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    // Simulate completion of first call
+    mockUseLLMSuggestion.mockReturnValue({
+      getSuggestion: mockGetSuggestion,
+      response: 'First AI suggestion',
+      isLoading: false,
+    });
+
+    rerender(
+      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <IssueDescription {...defaultProps} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('First AI suggestion')).toBeInTheDocument();
+
+    // Reset mock call count for second test
+    mockGetSuggestion.mockClear();
+
+    // Click the AI button again (it should toggle closed first, then open again)
+    await user.click(aiButton); // This closes it
+    await user.click(aiButton); // This opens it and calls getSuggestion again
+
+    // Verify getSuggestion was called again with same parameters
+    expect(mockGetSuggestion).toHaveBeenCalledWith('check1', 'step1', 'item1');
+    expect(mockGetSuggestion).toHaveBeenCalledTimes(1); // Called once after clear
+
+    // Simulate loading state for second call
+    mockUseLLMSuggestion.mockReturnValue({
+      getSuggestion: mockGetSuggestion,
+      response: 'First AI suggestion',
+      isLoading: true,
+    });
+
+    rerender(
+      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <IssueDescription {...defaultProps} />
+      </BrowserRouter>
+    );
+
+    // Verify loading is shown again
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows AI suggestion when LLM section is open', async () => {
+    const user = userEvent.setup();
+
+    mockUseLLMSuggestion.mockReturnValue({
+      getSuggestion: mockGetSuggestion,
+      response: 'This is an AI-generated suggestion for your issue.',
+      isLoading: false,
+    });
+
+    renderWithRouter(<IssueDescription {...defaultProps} />);
+
+    const aiButton = screen.getByTitle('Generate AI suggestion');
+    await user.click(aiButton);
+
+    expect(screen.getByTestId('llm-suggestion-content')).toBeInTheDocument();
+    expect(screen.getByText('This is an AI-generated suggestion for your issue.')).toBeInTheDocument();
+  });
+
+  it('does not show AI button when LLM is disabled', () => {
+    mockUsePluginContext.mockReturnValue({
+      isLLMEnabled: false,
+      isLoading: false,
+    });
+
+    renderWithRouter(<IssueDescription {...defaultProps} />);
+
+    expect(screen.queryByTitle('Generate AI suggestion')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('llm-suggestion-content')).not.toBeInTheDocument();
+  });
+
+  it('calls getSuggestion only when opening LLM section', async () => {
+    const user = userEvent.setup();
+
+    renderWithRouter(<IssueDescription {...defaultProps} />);
+
+    const aiButton = screen.getByTitle('Generate AI suggestion');
+
+    // First click - opens section and calls getSuggestion
+    await user.click(aiButton);
+    expect(mockGetSuggestion).toHaveBeenCalledTimes(1);
+
+    // Second click - closes section, should not call getSuggestion again
+    await user.click(aiButton);
+    expect(mockGetSuggestion).toHaveBeenCalledTimes(1); // Still only 1 call
+    expect(screen.queryByTestId('llm-suggestion-content')).not.toBeInTheDocument();
+  });
+
+  it('tracks interaction when AI suggestion button is clicked', async () => {
+    const user = userEvent.setup();
+
+    renderWithRouter(<IssueDescription {...defaultProps} />);
+
+    const aiButton = screen.getByTitle('Generate AI suggestion');
+    await user.click(aiButton);
+
+    expect(mockTrackCheckInteraction).toHaveBeenCalledWith('aisuggestion_clicked', 'dashboard-performance', 'step1');
+  });
+
+  it('handles retry button click with local loading state', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const mockOnRetryCheck = jest.fn();
+
+    renderWithRouter(<IssueDescription {...defaultProps} onRetryCheck={mockOnRetryCheck} />);
+
+    const retryButton = screen.getByTitle('Retry check');
+
+    // Initially button should be enabled
+    expect(retryButton).toBeEnabled();
+
+    await user.click(retryButton);
+
+    // After click, button should be disabled
+    expect(retryButton).toBeDisabled();
+    expect(mockOnRetryCheck).toHaveBeenCalledTimes(1);
+    expect(mockTrackCheckInteraction).toHaveBeenCalledWith('refresh_clicked', 'dashboard-performance', 'step1');
+
+    // After timeout, button should be enabled again
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(retryButton).toBeEnabled();
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('handles hide/show issue button click', async () => {
+    const user = userEvent.setup();
+    const mockOnHideIssue = jest.fn();
+
+    renderWithRouter(<IssueDescription {...defaultProps} onHideIssue={mockOnHideIssue} />);
+
+    const hideButton = screen.getByTitle('Hide issue');
+    await user.click(hideButton);
+
+    expect(mockOnHideIssue).toHaveBeenCalledWith(true);
+    expect(mockTrackCheckInteraction).toHaveBeenCalledWith('silence_clicked', 'dashboard-performance', 'step1', {
+      silenced: true,
+    });
+  });
+});

--- a/src/components/CheckDrillDown/IssueDescription.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.tsx
@@ -44,6 +44,7 @@ export function IssueDescription({
   const [llmSectionOpen, setLlmSectionOpen] = useState(false);
   const { getSuggestion, response, isLoading } = useLLMSuggestion();
   const { trackCheckInteraction } = useInteractionTracker();
+  const [localIsRetrying, setLocalIsRetrying] = useState(isRetrying);
 
   const handleStepClick = useCallback(
     (item: string) => {
@@ -106,12 +107,20 @@ export function IssueDescription({
           <Button
             size="sm"
             className={styles.issueLink}
-            icon={isRetrying ? 'spinner' : 'sync'}
+            icon={isRetrying || localIsRetrying ? 'spinner' : 'sync'}
             variant="secondary"
             title="Retry check"
-            disabled={!isCompleted}
+            disabled={isRetrying || localIsRetrying || !isCompleted}
             data-testid={testIds.CheckDrillDown.retryButton(item)}
-            onClick={handleRetryClick}
+            onClick={() => {
+              setLocalIsRetrying(true);
+              handleRetryClick();
+              setTimeout(() => {
+                // isRetrying and isCompleted can be either instantly true or take some time to change value
+                // so this ensures that the user is getting instant visual feedback that the check is being retried
+                setLocalIsRetrying(false);
+              }, 1000);
+            }}
           />
         )}
         {links.map((link) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export type CheckReportFailureExtended = CheckReportFailure & {
 
 export interface CheckStatus {
   name: string;
-  creationTimestamp: string;
   incomplete: boolean;
   hasError: boolean;
+  lastUpdate: Date;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,5 +15,5 @@ export function formatDate(date: Date): string {
 
 export const isOld = (check: CheckStatus) => {
   const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
-  return new Date(check.creationTimestamp).getTime() < tenMinutesAgo.getTime();
+  return tenMinutesAgo > check.lastUpdate;
 };


### PR DESCRIPTION
This PR includes two minor fixes regarding the retry item behavior:

 - Avoid to show a warning message when retrying a check. This was being shown because only the creation timestamp was being taken into account when deciding if a check was stale (unfinished and old). This PR also evaluates the latest update time to get a more accurate indicator (see behavior in the [issue description](https://github.com/grafana/grafana-advisor-app/issues/108)).
 - Instantly disable the "retry" button when clicking on it (without waiting for the API to report changes in the resources). This is to fix the weird behavior that the button seemed to do nothing after clicking it.
 
Second part of https://github.com/grafana/grafana-advisor-app/issues/108

Before:

https://github.com/user-attachments/assets/faea500e-9d60-4440-89fc-eb8e694c1205


After:

https://github.com/user-attachments/assets/92d00a5f-5b04-4cb2-819e-78117907187d

