### PR TITLE
ci: Switch to auto-cd workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,6 +41,5 @@ jobs:
       argo-workflow-slack-channel: "#grafana-plugins-platform-ci"
 
       # Other CI inputs
-      # Disable playwright tests for now
-      run-playwright: false
+      run-playwright: true
       node-version: 22

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v2.0.0 # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v2.0.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,18 +12,20 @@ on:
         required: true
         type: choice
         options:
-          - 'dev'
-          - 'ops'
-          - 'prod'
+          - "dev"
+          - "ops"
+          - "prod"
       docs-only:
         description: Only publish docs, do not publish the plugin
         default: false
         type: boolean
 
+permissions: {}
+
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v1.2.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v2.0.0 # zizmor: ignore[unpinned-uses]
     permissions:
       contents: write
       id-token: write
@@ -32,7 +34,13 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      # Disable playwright tests for now
-      run-playwright: false
+      scopes: universal
+      
+      # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
-      argo-workflow-slack-channel: '#grafana-plugins-platform-ci'
+      argo-workflow-slack-channel: "#grafana-plugins-platform-ci"
+
+      # Other CI inputs
+      # Disable playwright tests for now
+      run-playwright: false
+      node-version: 22

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v2.0.0 # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v2.0.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,4 +1,4 @@
-name: Plugins - CI
+name: Plugins - CI / CD
 
 on:
   push:
@@ -6,15 +6,35 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
-  ci:
-    name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v1.2.0
+  cd:
+    name: CI / CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v2.0.0 # zizmor: ignore[unpinned-uses]
     permissions:
-      contents: read
+      contents: write
       id-token: write
+      attestations: write
     with:
-      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      # Checkout/build PR or main branch, depending on event
+      branch: ${{ github.event_name == 'push' && github.ref_name || github.ref }}
+
+      # When pushing to "main", publish and deploy to Grafana Cloud (CD).
+      # For PRs, skip publishing and deploying (run CI only).
+      environment: ${{ (github.event_name == 'push' && github.ref_name == 'main') && 'dev' || 'none' }}
+
+      scopes: universal
+
+      # Argo CD inputs
+      grafana-cloud-deployment-type: provisioned
+      argo-workflow-slack-channel: "#grafana-plugins-platform-ci"
+      auto-merge-environments: dev
+
+      # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.
+      plugin-version-suffix: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
+
+      # Other CI inputs
       run-playwright: true
       upload-playwright-artifacts: true
       node-version: 22


### PR DESCRIPTION
- Switches to auto-cd-style workflows for ci/cd. This will publish a version to the catalog on every push to main and deploy it to Grafana Cloud dev, for a continuous-delivery-like approach (as per [this example](https://github.com/grafana/plugin-ci-workflows/tree/main/examples/base/provisioned-plugin-auto-cd))
- Bump plugin-ci-workflows to v2.0.0