### PR TITLE
Zero state redesign

### DIFF
--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -10,12 +10,19 @@ import { useInteractionTracker, GlobalActionType } from '../../api/useInteractio
 
 interface ActionsProps {
   isCompleted: boolean;
-  checkStatuses: CheckStatus[];
-  showHiddenIssues: boolean;
-  setShowHiddenIssues: (showHiddenIssues: boolean) => void;
+  checkStatuses?: CheckStatus[];
+  showHiddenIssues?: boolean;
+  setShowHiddenIssues?: (showHiddenIssues: boolean) => void;
+  emptyState?: boolean;
 }
 
-export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, setShowHiddenIssues }: ActionsProps) {
+export default function Actions({
+  isCompleted,
+  checkStatuses,
+  showHiddenIssues,
+  setShowHiddenIssues,
+  emptyState,
+}: ActionsProps) {
   const { createChecks, createCheckState } = useCreateChecks();
   const { deleteChecks, deleteChecksState } = useDeleteChecks();
   const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
@@ -39,11 +46,26 @@ export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, 
   };
 
   const handleToggleHiddenIssues = () => {
-    setShowHiddenIssues(!showHiddenIssues);
+    setShowHiddenIssues?.(!showHiddenIssues);
     trackGlobalAction(GlobalActionType.TOGGLE_HIDDEN_ISSUES, {
       show_hidden_issues: showHiddenIssues,
     });
   };
+
+  if (emptyState) {
+    return (
+      <div>
+        <Button
+          onClick={handleRefreshClick}
+          disabled={!isCompleted}
+          variant="primary"
+          icon={isCompleted ? 'sync' : 'spinner'}
+        >
+          {isCompleted ? 'Generate report' : 'Running checks...'}
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.actionsContainer}>
@@ -58,14 +80,16 @@ export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, 
             onDismiss={() => setConfirmDeleteModalOpen(false)}
           />
 
-          <Button
-            onClick={handleRefreshClick}
-            disabled={!isCompleted}
-            variant="secondary"
-            icon={isCompleted ? 'sync' : 'spinner'}
-          >
-            {isCompleted ? 'Refresh' : 'Running checks...'}
-          </Button>
+          {!emptyState && (
+            <Button
+              onClick={handleRefreshClick}
+              disabled={!isCompleted}
+              variant="secondary"
+              icon={isCompleted ? 'sync' : 'spinner'}
+            >
+              {isCompleted ? 'Refresh' : 'Running checks...'}
+            </Button>
+          )}
 
           <LinkButton
             icon="cog"
@@ -94,7 +118,7 @@ export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, 
           />
         </Stack>
 
-        <ChecksStatus checkStatuses={checkStatuses} />
+        <ChecksStatus checkStatuses={checkStatuses ?? []} />
 
         <div className={styles.rightColumn}>
           {createCheckState.isError && isFetchError(createCheckState.error) && (

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -10,19 +10,12 @@ import { useInteractionTracker, GlobalActionType } from '../../api/useInteractio
 
 interface ActionsProps {
   isCompleted: boolean;
-  checkStatuses?: CheckStatus[];
-  showHiddenIssues?: boolean;
-  setShowHiddenIssues?: (showHiddenIssues: boolean) => void;
-  emptyState?: boolean;
+  checkStatuses: CheckStatus[];
+  showHiddenIssues: boolean;
+  setShowHiddenIssues: (showHiddenIssues: boolean) => void;
 }
 
-export default function Actions({
-  isCompleted,
-  checkStatuses,
-  showHiddenIssues,
-  setShowHiddenIssues,
-  emptyState,
-}: ActionsProps) {
+export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, setShowHiddenIssues }: ActionsProps) {
   const { createChecks, createCheckState } = useCreateChecks();
   const { deleteChecks, deleteChecksState } = useDeleteChecks();
   const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
@@ -46,26 +39,11 @@ export default function Actions({
   };
 
   const handleToggleHiddenIssues = () => {
-    setShowHiddenIssues?.(!showHiddenIssues);
+    setShowHiddenIssues(!showHiddenIssues);
     trackGlobalAction(GlobalActionType.TOGGLE_HIDDEN_ISSUES, {
       show_hidden_issues: showHiddenIssues,
     });
   };
-
-  if (emptyState) {
-    return (
-      <div>
-        <Button
-          onClick={handleRefreshClick}
-          disabled={!isCompleted}
-          variant="primary"
-          icon={isCompleted ? 'sync' : 'spinner'}
-        >
-          {isCompleted ? 'Generate report' : 'Running checks...'}
-        </Button>
-      </div>
-    );
-  }
 
   return (
     <div className={styles.actionsContainer}>
@@ -80,16 +58,14 @@ export default function Actions({
             onDismiss={() => setConfirmDeleteModalOpen(false)}
           />
 
-          {!emptyState && (
-            <Button
-              onClick={handleRefreshClick}
-              disabled={!isCompleted}
-              variant="secondary"
-              icon={isCompleted ? 'sync' : 'spinner'}
-            >
-              {isCompleted ? 'Refresh' : 'Running checks...'}
-            </Button>
-          )}
+          <Button
+            onClick={handleRefreshClick}
+            disabled={!isCompleted}
+            variant="secondary"
+            icon={isCompleted ? 'sync' : 'spinner'}
+          >
+            {isCompleted ? 'Refresh' : 'Running checks...'}
+          </Button>
 
           <LinkButton
             icon="cog"
@@ -118,7 +94,7 @@ export default function Actions({
           />
         </Stack>
 
-        <ChecksStatus checkStatuses={checkStatuses ?? []} />
+        <ChecksStatus checkStatuses={checkStatuses} />
 
         <div className={styles.rightColumn}>
           {createCheckState.isError && isFetchError(createCheckState.error) && (

--- a/src/components/NoChecksEmptyState/NoChecksEmptyState.test.tsx
+++ b/src/components/NoChecksEmptyState/NoChecksEmptyState.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NoChecksEmptyState } from './NoChecksEmptyState';
+
+const mockCreateChecks = jest.fn();
+const mockTrackGlobalAction = jest.fn();
+
+jest.mock('api/api', () => ({
+  useCreateChecks: () => ({
+    createChecks: mockCreateChecks,
+  }),
+}));
+
+jest.mock('api/useInteractionTracker', () => ({
+  useInteractionTracker: () => ({
+    trackGlobalAction: mockTrackGlobalAction,
+  }),
+  GlobalActionType: {
+    REFRESH_CLICKED: 'REFRESH_CLICKED',
+  },
+}));
+
+describe('NoChecksEmptyState', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the empty state message', () => {
+    render(<NoChecksEmptyState isCompleted={true} />);
+
+    expect(screen.getByText('No checks run yet')).toBeInTheDocument();
+  });
+
+  describe('Generate report button', () => {
+    it('renders enabled button with "Generate report" text when checks are completed', () => {
+      render(<NoChecksEmptyState isCompleted={true} />);
+
+      const button = screen.getByRole('button', { name: /Generate report/i });
+      expect(button).toBeInTheDocument();
+      expect(button).toBeEnabled();
+    });
+
+    it('renders disabled button with "Running checks..." text when checks are not completed', () => {
+      render(<NoChecksEmptyState isCompleted={false} />);
+
+      const button = screen.getByRole('button', { name: /Running checks.../i });
+      expect(button).toBeInTheDocument();
+      expect(button).toBeDisabled();
+    });
+
+    it('calls createChecks and trackGlobalAction when button is clicked', async () => {
+      render(<NoChecksEmptyState isCompleted={true} />);
+
+      const button = screen.getByRole('button', { name: /Generate report/i });
+      await user.click(button);
+
+      expect(mockCreateChecks).toHaveBeenCalledTimes(1);
+      expect(mockTrackGlobalAction).toHaveBeenCalledTimes(1);
+      expect(mockTrackGlobalAction).toHaveBeenCalledWith('REFRESH_CLICKED');
+    });
+  });
+});

--- a/src/components/NoChecksEmptyState/NoChecksEmptyState.tsx
+++ b/src/components/NoChecksEmptyState/NoChecksEmptyState.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { Button, EmptyState, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { GlobalActionType, useInteractionTracker } from 'api/useInteractionTracker';
+import { useCreateChecks } from 'api/api';
+
+interface NoChecksEmptyStateProps {
+  isCompleted: boolean;
+}
+
+export function NoChecksEmptyState({ isCompleted }: NoChecksEmptyStateProps) {
+  const styles = useStyles2(getStyles);
+  const { createChecks } = useCreateChecks();
+  const { trackGlobalAction } = useInteractionTracker();
+
+  const handleCreateChecksClick = () => {
+    createChecks();
+    trackGlobalAction(GlobalActionType.REFRESH_CLICKED);
+  };
+
+  return (
+    <EmptyState variant="call-to-action" message="No checks run yet">
+      Advisor can analyze your Grafana setup and look for potential issues.
+      <br />
+      Once a report is generated, it will be automatically updated periodically.
+      <br />
+      Check the{' '}
+      <a
+        href="https://grafana.com/docs/grafana/latest/administration/grafana-advisor/"
+        target="_blank"
+        rel="noreferrer noopener"
+        className={styles.link}
+      >
+        documentation
+      </a>{' '}
+      for more information.
+      <div className={styles.createChecksButton}>
+        <Button
+          onClick={handleCreateChecksClick}
+          disabled={!isCompleted}
+          variant="primary"
+          icon={isCompleted ? 'plus' : 'spinner'}
+        >
+          {isCompleted ? 'Generate report' : 'Running checks...'}
+        </Button>
+      </div>
+    </EmptyState>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  link: css({
+    color: theme.colors.text.link,
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  }),
+  createChecksButton: css({
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/src/components/NoChecksEmptyState/index.ts
+++ b/src/components/NoChecksEmptyState/index.ts
@@ -1,0 +1,1 @@
+export { NoChecksEmptyState } from './NoChecksEmptyState';

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -161,7 +161,7 @@ describe('Home', () => {
     });
 
     renderWithRouter(<Home />);
-    expect(await screen.findByText(/No report found/)).toBeInTheDocument();
+    expect(await screen.findByText(/No checks run yet/)).toBeInTheDocument();
   });
 
   it('shows completed state when no issues found', async () => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import Actions from 'components/Actions/Actions';
 import { useCheckSummaries, useCompletedChecks, useRetryCheck } from 'api/api';
 import { formatDate } from 'utils';
 import { InfoNotification } from 'components/InfoNotification/InfoNotification';
+import { NoChecksEmptyState } from 'components/NoChecksEmptyState';
 
 export default function Home() {
   const styles = useStyles2(getStyles);
@@ -49,12 +50,14 @@ export default function Home() {
         subTitle: 'Run checks and get suggested action items to fix identified issues',
       }}
       actions={
-        <Actions
-          isCompleted={isCompleted}
-          checkStatuses={checkStatuses}
-          showHiddenIssues={showHiddenIssues}
-          setShowHiddenIssues={setShowHiddenIssues}
-        />
+        !isEmpty ? (
+          <Actions
+            isCompleted={isCompleted}
+            checkStatuses={checkStatuses}
+            showHiddenIssues={showHiddenIssues}
+            setShowHiddenIssues={setShowHiddenIssues}
+          />
+        ) : null
       }
     >
       <Stack direction="row" gap={1} justifyContent="space-between" alignItems="center">
@@ -103,9 +106,7 @@ export default function Home() {
         )}
 
         {/* Empty state */}
-        {isEmpty && (
-          <EmptyState variant="not-found" message="No report found. Click the Refresh button to run analysis." />
-        )}
+        {isEmpty && <NoChecksEmptyState isCompleted={isCompleted} />}
 
         {/* All issues resolved */}
         {isHealthy && <EmptyState variant="completed" message="No issues found." />}
@@ -182,13 +183,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     '&:hover': {
       textDecoration: 'underline',
-    },
-  }),
-  link: css({
-    color: theme.colors.text.secondary,
-    fontSize: theme.typography.bodySmall.fontSize,
-    ':hover': {
-      color: theme.colors.text.link,
     },
   }),
   error: css({

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -6,9 +6,16 @@ import { testIds } from '../src/components/testIds';
 async function expectEmptyReport(gotoPage: (path?: string) => Promise<AppPage>, page: Page) {
   await gotoPage(`/`);
   await expect(page.getByText('Run checks and get suggested action items to fix identified issues')).toBeVisible();
-  // It should delete the report
-  await page.getByRole('button', { name: 'Delete reports' }).click();
-  await page.getByRole('button', { name: 'Confirm' }).click();
+
+  // Check if page is already empty
+  const isAlreadyEmpty = await page.getByText('No report found').isVisible();
+
+  if (!isAlreadyEmpty) {
+    // Delete the report if it exists
+    await page.getByRole('button', { name: 'Delete reports' }).click();
+    await page.getByRole('button', { name: 'Confirm' }).click();
+  }
+
   // Page should be empty
   await expect(page.getByText('No report found')).toBeVisible();
 }


### PR DESCRIPTION
Closes https://github.com/grafana/grafana-community-team/issues/555

The goal is to show a less "error-y" message when there are no checks run (which will be the default state when first running Grafana). More details about the desing in the [issue](https://github.com/grafana/grafana-community-team/issues/555).

<img width="1212" height="826" alt="Screenshot 2025-10-16 at 13 12 00" src="https://github.com/user-attachments/assets/b78cacec-07c4-405f-8cd9-0b21cf1c88c0" />
