### PR TITLE
renovate: don't major bump react or its types

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,10 @@
       "enabled": false
     },
     {
-      "groupName": "React ecosystem",
-      "matchPackageNames": ["/^react$/", "/^react-/", "/^@types/react/"]
+      "groupName": "React",
+      "matchPackageNames": ["/^react$/", "/^@types/react/"],
+      "updateTypes": ["major"],
+      "enabled": false
     },
     {
       "groupName": "Testing tools",

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,8 @@
       "enabled": false
     },
     {
-      "groupName": "React",
-      "matchPackageNames": ["/^react$/", "/^@types/react/"],
+      "groupName": "React and React DOM",
+      "matchPackageNames": ["/^react$/", "/^@types/react/", "/^react-dom$/", "/^@types/react-dom/"],
       "updateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION
This PR should stop Renovate from [opening PRs](https://github.com/grafana/grafana-advisor-app/pull/171) that major bump react or it's types. To do this the grafana packages will need to signal react 19 as a peer dep and likely react related test packages would also need bumping.