### PR TITLE
Consistent button style

### DIFF
--- a/src/components/Actions/Actions.test.tsx
+++ b/src/components/Actions/Actions.test.tsx
@@ -47,7 +47,7 @@ describe('Actions', () => {
   it('shows loading state when running checks', async () => {
     render(<Actions {...defaultProps} isCompleted={false} />);
     await waitFor(() => {
-      expect(screen.getByText('Running checks...')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Running checks...' })).toBeInTheDocument();
     });
   });
 

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -57,25 +57,22 @@ export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, 
             onConfirm={handlePurgeClick}
             onDismiss={() => setConfirmDeleteModalOpen(false)}
           />
-
           <Button
             onClick={handleRefreshClick}
             disabled={!isCompleted}
             variant="secondary"
             icon={isCompleted ? 'sync' : 'spinner'}
+            tooltip={isCompleted ? 'Refresh' : 'Running checks...'}
           >
-            {isCompleted ? 'Refresh' : 'Running checks...'}
           </Button>
-
           <LinkButton
             icon="cog"
             variant="secondary"
             aria-label="Configuration"
-            tooltip="Configure advisor steps"
+            tooltip="Configure application"
             href="/plugins/grafana-advisor-app?page=configuration"
             onClick={handleConfigureClick}
           />
-
           <Button
             variant="secondary"
             icon={showHiddenIssues ? 'eye' : 'eye-slash'}
@@ -83,7 +80,6 @@ export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, 
             tooltip={showHiddenIssues ? 'Hide silenced issues' : 'Show silenced issues'}
             onClick={handleToggleHiddenIssues}
           />
-
           <Button
             onClick={() => setConfirmDeleteModalOpen(true)}
             disabled={deleteChecksState.isLoading}

--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -62,6 +62,7 @@ export default function Actions({ isCompleted, checkStatuses, showHiddenIssues, 
             disabled={!isCompleted}
             variant="secondary"
             icon={isCompleted ? 'sync' : 'spinner'}
+            aria-label={isCompleted ? 'Refresh' : 'Running checks...'}
             tooltip={isCompleted ? 'Refresh' : 'Running checks...'}
           >
           </Button>

--- a/src/components/CheckDrillDown/CheckDrillDown.test.tsx
+++ b/src/components/CheckDrillDown/CheckDrillDown.test.tsx
@@ -117,7 +117,8 @@ describe('Components/CheckDrillDown', () => {
     const user = userEvent.setup();
     await user.click(screen.getByText(/Step 1 failed/i));
 
-    expect(screen.getByRole('button', { name: 'Retry check' })).toBeDisabled();
+    const retryButton = screen.getByRole('button', { name: 'Retry check' });
+    expect(retryButton).toHaveAttribute('aria-disabled', 'true');
   });
 
   test('should call the handleHideIssue function when the hide button is clicked', async () => {

--- a/src/components/CheckDrillDown/IssueDescription.test.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.test.tsx
@@ -49,10 +49,10 @@ describe('IssueDescription', () => {
     renderWithRouter(<IssueDescription {...defaultProps} />);
 
     expect(screen.getByText(defaultProps.item)).toBeInTheDocument();
-    expect(screen.getByTitle('Hide issue')).toBeInTheDocument();
-    expect(screen.getByTitle('Retry check')).toBeInTheDocument();
-    expect(screen.getByText('Fix this issue')).toBeInTheDocument();
-    expect(screen.getByText('More info')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide issue' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry check' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Fix this issue' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'More info' })).toBeInTheDocument();
   });
 
   it('renders the AI suggestion button when the LLM plugin is available', () => {
@@ -64,8 +64,8 @@ describe('IssueDescription', () => {
     });
 
     renderWithRouter(<IssueDescription {...defaultProps} />);
-    expect(screen.getByTitle('Generate AI suggestion')).toBeInTheDocument();
-    expect(screen.queryByText('Ask Assistant')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Generate AI suggestion' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Ask Assistant' })).toBeNull();
   });
 
   it('renders the Ask Assistant button when the Assistant plugin is available', () => {
@@ -76,8 +76,8 @@ describe('IssueDescription', () => {
     });
 
     renderWithRouter(<IssueDescription {...defaultProps} />);
-    expect(screen.queryByTitle('Generate AI suggestion')).toBeNull();
-    expect(screen.getByText('Ask Assistant')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Generate AI suggestion' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Ask Assistant' })).toBeInTheDocument();
   });
 
   it('prefers Assistant when both the LLM and Assistant plugins are available', () => {
@@ -95,8 +95,8 @@ describe('IssueDescription', () => {
     });
 
     renderWithRouter(<IssueDescription {...defaultProps} />);
-    expect(screen.queryByTitle('Generate AI suggestion')).toBeNull();
-    expect(screen.getByText('Ask Assistant')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Generate AI suggestion' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Ask Assistant' })).toBeInTheDocument();
   });
 
   it('handles retry button click with local loading state', async () => {
@@ -106,15 +106,15 @@ describe('IssueDescription', () => {
 
     renderWithRouter(<IssueDescription {...defaultProps} onRetryCheck={mockOnRetryCheck} />);
 
-    const retryButton = screen.getByTitle('Retry check');
+    const retryButton = screen.getByRole('button', { name: 'Retry check' });
 
-    // Initially button should be enabled
-    expect(retryButton).toBeEnabled();
+    // Initially button should be enabled (Grafana Button uses aria-disabled, not disabled)
+    expect(retryButton).toHaveAttribute('aria-disabled', 'false');
 
     await user.click(retryButton);
 
     // After click, button should be disabled
-    expect(retryButton).toBeDisabled();
+    expect(retryButton).toHaveAttribute('aria-disabled', 'true');
     expect(mockOnRetryCheck).toHaveBeenCalledTimes(1);
 
     // After timeout, button should be enabled again
@@ -123,7 +123,7 @@ describe('IssueDescription', () => {
     });
 
     await waitFor(() => {
-      expect(retryButton).toBeEnabled();
+      expect(retryButton).toHaveAttribute('aria-disabled', 'false');
     });
 
     jest.useRealTimers();

--- a/src/components/CheckDrillDown/IssueDescription.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { Button, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, IconName } from '@grafana/data';
 import { useNavigate } from 'react-router-dom';
@@ -90,32 +90,29 @@ export function IssueDescription({
         {item}
         {isLLMAvailable && !isAssistantAvailable && (
           <Button
-            size="sm"
             className={styles.issueLink}
             icon="ai"
             variant={llmSectionOpen ? 'primary' : 'secondary'}
             title={llmSectionOpen ? 'Hide AI suggestion' : 'Generate AI suggestion'}
             onClick={handleAISuggestionClick}
             aria-label={llmSectionOpen ? 'Hide AI suggestion' : 'Generate AI suggestion'}
+            tooltip={llmSectionOpen ? 'Hide AI suggestion' : 'Generate AI suggestion'}
           />
         )}
         <Button
-          size="sm"
           className={styles.issueLink}
           icon={isHidden ? 'bell' : 'bell-slash'}
           variant="secondary"
-          title={isHidden ? 'Show issue' : 'Hide issue'}
           data-testid={testIds.CheckDrillDown.hideButton(item)}
           onClick={handleSilenceClick}
           aria-label={isHidden ? 'Show issue' : 'Hide issue'}
+          tooltip={isHidden ? 'Show issue' : 'Hide issue'}
         />
         {canRetry && (
           <Button
-            size="sm"
             className={styles.issueLink}
             icon={isRetrying || localIsRetrying ? 'spinner' : 'sync'}
             variant="secondary"
-            title="Retry check"
             disabled={isRetrying || localIsRetrying || !isCompleted}
             data-testid={testIds.CheckDrillDown.retryButton(item)}
             onClick={() => {
@@ -128,33 +125,30 @@ export function IssueDescription({
               }, 1000);
             }}
             aria-label="Retry check"
+            tooltip="Retry check"
           />
         )}
         {isAssistantAvailable && (
           <Button
-            size="sm"
-            className={styles.issueLink}
+            className={cx(styles.issueLink, styles.assistantButton)}
             icon={isAssistantLoading ? 'spinner' : 'ai'}
             variant="secondary"
             disabled={isAssistantLoading}
             onClick={handleAskAssistantClick}
-          >
-            Ask Assistant
-          </Button>
+            tooltip="Ask Assistant"
+          />
         )}
         {links.map((link) => {
           const extraProps = link.url.startsWith('http') ? { target: 'blank', rel: 'noopener noreferrer' } : {};
           return (
             <a key={link.url} href={link.url} onClick={handleResolutionClick} {...extraProps}>
               <Button
-                size="sm"
                 className={styles.issueLink}
                 icon={getIcon(link.message)}
-                variant="secondary"
+                variant="primary"
                 data-testid={testIds.CheckDrillDown.actionLink(item, link.message)}
-              >
-                {link.message}
-              </Button>
+                tooltip={link.message}
+              />
             </a>
           );
         })}
@@ -197,6 +191,16 @@ const getStyles = (theme: GrafanaTheme2) => ({
   issueLink: css({
     float: 'right',
     marginLeft: theme.spacing(1),
+  }),
+  // Rainbow-style gradient for Assistant integration (matches Grafana Assistant button branding)
+  assistantButton: css({
+    border: '1px solid transparent',
+    background: `linear-gradient(rgb(55 57 64), rgb(55 57 64)) padding-box,
+      linear-gradient(135deg, #F97316 0%, #A855F7 100%) border-box`,
+    '&:hover:not(:disabled)': {
+      background: `linear-gradient(rgb(55 57 64), rgb(55 57 64)) padding-box,
+        linear-gradient(135deg, #fb923c 0%, #c084fc 100%) border-box`,
+    },
   }),
 });
 

--- a/tests/appNavigation.spec.ts
+++ b/tests/appNavigation.spec.ts
@@ -48,10 +48,10 @@ async function runChecks(gotoPage: (path?: string) => Promise<AppPage>, page: Pa
   // Sometimes the checks complete so quickly that "Running checks..." doesn't render.
   // In that case, we verify completion by checking for "Last checked" text.
   await page
-    .getByText('Running checks...')
+    .getByRole('button', { name: 'Running checks...' })
     .isVisible({ timeout: 2000 })
     .catch(() => false);
-  await expect(page.getByText('Running checks...')).not.toBeVisible();
+  await expect(page.getByRole('button', { name: 'Running checks...' })).not.toBeVisible();
   await expect(page.getByText('Last checked')).toBeVisible();
 }
 
@@ -103,8 +103,8 @@ test.describe('navigating app', () => {
     if (grafanaVersion.startsWith('12.0')) {
       // "Retry" button is not available in Grafana 12.0
       await page.getByRole('button', { name: 'Refresh' }).click();
-      await expect(page.getByText('Running checks...')).toBeVisible();
-      await expect(page.getByText('Running checks...')).not.toBeVisible();
+      await expect(page.getByRole('button', { name: 'Running checks...' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Running checks...' })).not.toBeVisible();
     } else {
       await page.getByTestId(testIds.CheckDrillDown.retryButton(dsName)).click();
     }


### PR DESCRIPTION
The goal of this PR is to have a consistent style for all the buttons of the app (the global ones and the ones per check) and avoid repetitive text. I have decided to use the style that is present in most of the Grafana pages, a button with an icon only which has more information as a tooltip, giving extra importance to the buttons given by the check (e.g. "Fix me") and  extra styling for the Assistant button to make it more discoverable:

Before:
<img width="892" height="752" alt="Screenshot 2026-01-29 at 13 41 48" src="https://github.com/user-attachments/assets/613ea56d-bef2-4966-b644-c4fa903d52f5" />

After:
<img width="890" height="686" alt="Screenshot 2026-01-29 at 13 41 20" src="https://github.com/user-attachments/assets/2857c0b3-15a0-469f-bb39-e8aada1b28cd" />

Fixes https://github.com/grafana/grafana-advisor-app/issues/169