### PR TITLE
Fix publish workflow permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,16 +20,16 @@ on:
         default: false
         type: boolean
 
-permissions: {}
+permissions:
+  pull-requests: read
+  contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   cd:
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.0.0
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-advisor-app/actions/runs/21667240724/workflow#L26