### PR TITLE
ci: silence argo slack notifications for dev deployments

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.1.0
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.1.0
     permissions:
       contents: write
       id-token: write
@@ -30,6 +30,14 @@ jobs:
       # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
       argo-workflow-slack-channel: "#grafana-plugins-platform-ci"
+      argo-workflow-slack-silent: |-
+        ${{ case(
+          inputs.environment == 'dev',
+          true,
+
+          inputs.environment == 'prod-canary' || inputs.environment == 'prod',
+          false
+        ) }}
       auto-merge-environments: dev
 
       # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,14 +30,7 @@ jobs:
       # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
       argo-workflow-slack-channel: "#grafana-plugins-platform-ci"
-      argo-workflow-slack-silent: |-
-        ${{ case(
-          inputs.environment == 'dev',
-          true,
-
-          inputs.environment == 'prod-canary' || inputs.environment == 'prod',
-          false
-        ) }}
+      argo-workflow-slack-silent: ${{ inputs.environment == 'dev' }}
       auto-merge-environments: dev
 
       # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.


### PR DESCRIPTION
Uses the new `argo-workflow-slack-silent` input of plugin-ci-workflows cd to silence slack notifications for dev deployments from the main branch. Failures will still be sent in Slack