### PR TITLE
ci: fix silent argo slack notifications

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,7 +30,8 @@ jobs:
       # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
       argo-workflow-slack-channel: "#grafana-plugins-platform-ci"
-      argo-workflow-slack-silent: ${{ inputs.environment == 'dev' }}
+      # Silence notifications when deploying from main branch to dev
+      argo-workflow-slack-silent: true
       auto-merge-environments: dev
 
       # Add the git head ref sha to the plugin version as suffix (`+abcdef`). This is required for CD builds.


### PR DESCRIPTION
Fixes an issue with #272.

The `push.yml` workflow is only called for pushes to `main` and PRs, but deployment happens only for pushes to `main`, so `argo-workflows-slack-silent` should be always set to `true`. Also this workflow is not a `workflow_dispatch` one, so `inputs.` isn't available.