### PR TITLE
fix assistant button in light theme

### DIFF
--- a/src/components/CheckDrillDown/IssueDescription.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.tsx
@@ -195,10 +195,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
   // Rainbow-style gradient for Assistant integration (matches Grafana Assistant button branding)
   assistantButton: css({
     border: '1px solid transparent',
-    background: `linear-gradient(rgb(55 57 64), rgb(55 57 64)) padding-box,
+    background: `linear-gradient(${theme.colors.secondary.main}, ${theme.colors.secondary.main}) padding-box,
+      linear-gradient(${theme.colors.background.canvas}, ${theme.colors.background.canvas}) padding-box,
       linear-gradient(135deg, #F97316 0%, #A855F7 100%) border-box`,
     '&:hover:not(:disabled)': {
-      background: `linear-gradient(rgb(55 57 64), rgb(55 57 64)) padding-box,
+      background: `linear-gradient(${theme.colors.emphasize(theme.colors.secondary.main, 0.05)}, ${theme.colors.emphasize(theme.colors.secondary.main, 0.05)}) padding-box,
+        linear-gradient(${theme.colors.background.canvas}, ${theme.colors.background.canvas}) padding-box,
         linear-gradient(135deg, #fb923c 0%, #c084fc 100%) border-box`,
     },
   }),


### PR DESCRIPTION
# Fix: Assistant button renders correctly in light theme

Fixes https://github.com/grafana/grafana-advisor-app/issues/281

## Problem

The Assistant button in the Advisor drilldown view used a hardcoded dark background color (`rgb(55 57 64)`) that looked correct in dark theme but stayed dark in light theme, making it nearly invisible against a light background.

## Fix

Replace the hardcoded color with theme-aware tokens in [IssueDescription.tsx](https://github.com/grafana/grafana-advisor-app/blob/b0c8df5/src/components/CheckDrillDown/IssueDescription.tsx#L196-L206), matching the pattern established by the assistant app's own [OpenAssistantButton](https://github.com/grafana/grafana-assistant-app/blob/f6e18844ad/packages/@grafana/assistant/src/components/button/OpenAssistantButton.tsx#L104-L140):

- [theme.colors.secondary.main](https://github.com/grafana/grafana/blob/a9f59fac653/packages/grafana-data/src/themes/createColors.ts#L233) as the button surface color. Because it can be semi-transparent, it is composited over [theme.colors.background.canvas](https://github.com/grafana/grafana/blob/a9f59fac653/packages/grafana-data/src/themes/createColors.ts#L268) to produce an opaque fill. This is the same two-layer compositing technique used in [solidBackgroundLayer](https://github.com/grafana/grafana-assistant-app/blob/f6e18844ad/packages/@grafana/assistant/src/components/button/OpenAssistantButton.tsx#L130-L136) in the assistant app.

- Both inner layers are clipped to `padding-box` so the orange-to-purple gradient border remains visible through the transparent border area.

- The hover state uses [theme.colors.emphasize](https://github.com/grafana/grafana/blob/a9f59fac653/packages/grafana-data/src/themes/colorManipulator.ts#L262-L264) with a `0.05` factor to subtly shift the surface color, consistent with how the assistant app computes its [elevatedBackground](https://github.com/grafana/grafana-assistant-app/blob/f6e18844ad/packages/@grafana/assistant/src/components/button/OpenAssistantButton.tsx#L106). Under the hood, `emphasize` darkens light colors and lightens dark ones based on luminance, so it does the right thing in both themes automatically.



# dark - hover 
<img width="245" height="110" alt="image" src="https://github.com/user-attachments/assets/2b9ad07a-8e7a-4d89-b030-915245c32e9a" />

# dark - no hover

<img width="264" height="169" alt="image" src="https://github.com/user-attachments/assets/7ed7264a-1983-4dd1-ad1d-55bfc7705cbc" />

# light - hover

<img width="278" height="162" alt="image" src="https://github.com/user-attachments/assets/7f9a91ff-5620-4512-9565-3d8edb9c690b" />

# light - no hover

<img width="264" height="166" alt="image" src="https://github.com/user-attachments/assets/14d7523e-55e3-4307-9bfc-11af236d0b4c" />
