### PR TITLE
chore: migrate plugin-ci-workflows to ci-cd-workflows/v8.0.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   cd:
     name: CI / CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v7.3.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Bumps both CI and CD workflows from ci-cd-workflows/v7.3.1 to v8.0.0.

v8 introduces GATB (GitHub App Token Broker) for short-lived token auth,
replacing the long-lived token that will be revoked. No deployment_tools
changes needed - this plugin doesn't use private Go deps, docs publishing,
release-please, or version-bump-changelog.