### PR TITLE
chore: group non-major npm updates to reduce renovate PR volume

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
       "enabled": false
     },
     {
+      "groupName": "All non-major npm dependencies",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+    },
+    {
       "groupName": "Testing tools",
       "matchPackageNames": [
         "/^jest$/",


### PR DESCRIPTION
Renovate is opening a separate PR for every loose dependency in this repo (immutable, js-cookie, react-use, semver, @types/node, the react/react-router monorepos, etc.), which floods the board's In Review column.

This adds an "All non-major npm dependencies" catch-all that folds minor/patch/pin/digest npm updates into one weekly PR. It's placed before the existing Testing tools / Build tools / TypeScript groups so those keep their own grouped PRs, and major updates still come through individually so they can be reviewed on their own.