### PR TITLE
Defer check-type registration to createChecks

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -34,6 +34,8 @@ jest.unmock('api/api');
 // Mock the generated API hooks
 const mockListCheckQuery = jest.fn();
 const mockListCheckTypeQuery = jest.fn();
+const mockLazyListCheckTypeQueryTrigger = jest.fn();
+const mockLazyListCheckTypeQuery = jest.fn().mockReturnValue([mockLazyListCheckTypeQueryTrigger, { isLoading: false }]);
 const mockCreateCheckMutation = jest.fn();
 const mockDeleteCheckMutation = jest.fn();
 const mockUpdateCheckMutation = jest.fn();
@@ -49,6 +51,7 @@ const mockCreateRegisterMutation = jest.fn().mockReturnValue([
 jest.mock('generated', () => ({
   useListCheckQuery: (arg0: any, arg1: any) => mockListCheckQuery(arg0, arg1),
   useListCheckTypeQuery: (arg0: any, arg1: any) => mockListCheckTypeQuery(arg0, arg1),
+  useLazyListCheckTypeQuery: () => mockLazyListCheckTypeQuery(),
   useCreateCheckMutation: () => mockCreateCheckMutation(),
   useDeleteCheckMutation: () => mockDeleteCheckMutation(),
   useUpdateCheckMutation: () => mockUpdateCheckMutation(),
@@ -676,15 +679,13 @@ describe('API Hooks', () => {
       ];
 
       mockCreateCheckMutation.mockReturnValue([mockCreateCheck, { isError: false }]);
-      mockListCheckTypeQuery.mockReturnValue({
-        data: { items: mockCheckTypes },
-        isLoading: false,
-        isError: false,
+      mockLazyListCheckTypeQueryTrigger.mockReturnValue({
+        unwrap: jest.fn().mockResolvedValue({ items: mockCheckTypes }),
       });
 
       const { result } = renderHook(() => useCreateChecks());
-      await waitFor(() => {
-        result.current.createChecks();
+      await act(async () => {
+        await result.current.createChecks();
       });
 
       expect(mockCreateCheck).toHaveBeenCalledWith({

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,6 +3,7 @@ import {
   Check,
   useListCheckQuery,
   useListCheckTypeQuery,
+  useLazyListCheckTypeQuery,
   useCreateCheckMutation,
   useDeleteCheckMutation,
   useUpdateCheckMutation,
@@ -286,31 +287,56 @@ export function useLastChecks() {
 }
 
 export function useCreateChecks() {
-  const { checkTypes } = useCheckTypes();
+  const [createRegister] = useCreateRegisterMutation();
+  const [fetchCheckTypes] = useLazyListCheckTypeQuery();
   const [createCheck, createCheckState] = useCreateCheckMutation();
+  const [isCreating, setIsCreating] = useState(false);
 
-  const createChecks = useCallback(() => {
-    if (!checkTypes) {
-      return;
-    }
-    for (const type of checkTypes) {
-      createCheck({
-        check: {
-          kind: 'Check',
-          apiVersion: 'advisor.grafana.app/v0alpha1',
-          spec: { data: {} },
-          metadata: {
-            generateName: 'check-',
-            labels: { 'advisor.grafana.app/type': type.metadata.name ?? '' },
-            namespace: config.namespace,
+  // Register + fetch check types lazily, only when the user actually triggers a
+  // run. This hook is exposed as an extension point that mounts on every
+  // datasource page, so doing this at render time (via useCheckTypes/useRegister)
+  // would hit the /register endpoint on every page view even when no checks are run.
+  const createChecks = useCallback(async () => {
+    setIsCreating(true);
+    try {
+      // Registration is on-demand in MT and idempotent; best-effort so a failure
+      // here still lets us attempt to list already-registered check types.
+      try {
+        await createRegister().unwrap();
+      } catch (error) {
+        console.error('Failed to register check types:', error);
+      }
+
+      const checkTypes = (await fetchCheckTypes({}).unwrap()).items;
+      if (!checkTypes) {
+        return;
+      }
+      for (const type of checkTypes) {
+        createCheck({
+          check: {
+            kind: 'Check',
+            apiVersion: 'advisor.grafana.app/v0alpha1',
+            spec: { data: {} },
+            metadata: {
+              generateName: 'check-',
+              labels: { 'advisor.grafana.app/type': type.metadata.name ?? '' },
+              namespace: config.namespace,
+            },
+            status: { report: { count: 0, failures: [] } },
           },
-          status: { report: { count: 0, failures: [] } },
-        },
-      });
+        });
+      }
+    } catch (error) {
+      console.error('Failed to create checks:', error);
+    } finally {
+      setIsCreating(false);
     }
-  }, [createCheck, checkTypes]);
+  }, [createRegister, fetchCheckTypes, createCheck]);
 
-  return { createChecks, createCheckState };
+  return {
+    createChecks,
+    createCheckState: { ...createCheckState, isLoading: isCreating || createCheckState.isLoading },
+  };
 }
 
 export function useDeleteChecks() {

--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -48,6 +48,7 @@ export const {
   useDeleteCheckMutation,
   useUpdateCheckMutation,
   useListCheckTypeQuery,
+  useLazyListCheckTypeQuery,
   useUpdateCheckTypeMutation,
 } = advisorAPIv0alpha1;
 export { type Check, type CheckType } from './endpoints.gen';


### PR DESCRIPTION
## Why

Removes an unnecesary `/register` call when viewing datasources.

## Problem

The `useCreateChecks` hook is exposed as a plugin extension point (`grafana/advisor/create-checks/v1`) that Grafana core mounts on **every datasource list/edit page** (via `AdvisorCheckProvider` → `AdvisorCheckBridge`).

It previously called `useCheckTypes()` at render time, which transitively runs `useRegister()` and fires a `POST /apis/advisor.grafana.app/v0alpha1/namespaces/<ns>/register` on every datasource page view — even when the user never runs any checks. The registration is only actually needed when checks are created.

## Change

Register and fetch check types **lazily, inside `createChecks()`**, using `useCreateRegisterMutation` + `useLazyListCheckTypeQuery` instead of the render-time `useCheckTypes()`. As a result `/register` is only hit when the user clicks "Enable Advisor checks".

The button's loading state now also covers the register/fetch phase via a local `isCreating` flag (previously it only reflected the `createCheck` mutation).
