### PR TITLE
fix(renovate): only run approve workflow on renovate branches

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -21,7 +21,9 @@ concurrency:
 jobs:
   approve:
     name: Renovate approve
-    if: github.event.pull_request.user.login == 'renovate-sh-app[bot]'
+    # pull_request branch filters only match the base branch, so the head
+    # branch has to be checked here at the job level.
+    if: github.event.pull_request.user.login == 'renovate-sh-app[bot]' && startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
       # Only judge PRs whose deterministic checks already passed cleanly.


### PR DESCRIPTION
The renovate-approve job was gated only on the PR author. This adds a head branch check (`renovate/*`) to the job condition, so the approval flow only runs on actual Renovate branches. The author check stays since a branch name alone is spoofable by anyone with write access.

Done at the job level because `on.pull_request.branches` only filters the base branch.