### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.2
+
+### Bug Fixes
+
+- Defer check-type registration to createChecks (#350)
+- Remove levitate Grafana API compatibility check (#291)
+- Remove duplicated Advisor breadcrumb (#286)
+
+### Dependencies
+
+- Update dependencies
+
 ## 1.0.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "advisor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",


### PR DESCRIPTION
Bump the package version to `1.0.2` and update the changelog for changes since `v1.0.1`.

### Bug Fixes

- Defer check-type registration to createChecks (#350)
- Remove levitate Grafana API compatibility check (#291)
- Remove duplicated Advisor breadcrumb (#286)

### Dependencies

- Update dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)