### PR TITLE
ci: add sweeper to rerun cancelled checks on renovate prs

### DIFF
--- a/.github/workflows/renovate-rerun-sweeper.yml
+++ b/.github/workflows/renovate-rerun-sweeper.yml
@@ -1,0 +1,63 @@
+name: Renovate rerun sweeper
+
+# Renovate PRs get permanently stuck when a runner eviction cancels one of
+# their checks: the cancelled check never re-runs on its own, the Renovate
+# approve workflow fails its wait step, and nothing fires a new pull_request
+# event to retry either one (renovate only rebases on conflict). This sweep
+# re-runs infra-cancelled runs so auto-merge can complete. Genuine CI
+# failures are left alone.
+
+on:
+  schedule:
+    - cron: '23 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write
+
+jobs:
+  sweep:
+    name: Rerun cancelled checks on renovate PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find stuck PRs and rerun
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Give up after this many attempts per run; if the infrastructure
+          # keeps cancelling the same job, a human should look at it.
+          MAX_ATTEMPTS: 3
+        run: |
+          set -euo pipefail
+
+          gh pr list --author 'app/renovate-sh-app' --state open --limit 100 \
+            --json number,headRefName,headRefOid \
+            --jq '.[] | select(.headRefName | startswith("renovate/")) | [.number, .headRefOid] | @tsv' |
+          while IFS=$'\t' read -r pr sha; do
+            runs=$(gh api "repos/$GH_REPO/actions/runs?head_sha=$sha&per_page=100" \
+              --jq '[.workflow_runs[] | {id, name, status, conclusion, run_attempt}]')
+
+            cancelled=$(jq -r --argjson max "$MAX_ATTEMPTS" \
+              '.[] | select(.status == "completed" and .conclusion == "cancelled" and .run_attempt < $max) | .id' \
+              <<<"$runs")
+            if [ -z "$cancelled" ]; then
+              continue
+            fi
+
+            for id in $cancelled; do
+              echo "PR #$pr: rerunning cancelled run $id"
+              gh api -X POST "repos/$GH_REPO/actions/runs/$id/rerun" || true
+            done
+
+            # The approve workflow fails terminally when a check it waited on
+            # was cancelled; rerun it so it waits on the fresh attempt.
+            jq -r --argjson max "$MAX_ATTEMPTS" \
+              '.[] | select(.name == "Renovate approve" and .status == "completed" and .conclusion == "failure" and .run_attempt < $max) | .id' \
+              <<<"$runs" |
+            while read -r id; do
+              echo "PR #$pr: rerunning failed Renovate approve run $id"
+              gh api -X POST "repos/$GH_REPO/actions/runs/$id/rerun-failed-jobs" || true
+            done
+          done

--- a/.github/workflows/renovate-rerun-sweeper.yml
+++ b/.github/workflows/renovate-rerun-sweeper.yml
@@ -9,7 +9,7 @@ name: Renovate rerun sweeper
 
 on:
   schedule:
-    - cron: '23 * * * *'
+    - cron: '23 7-15 * * 1-4'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Same sweep as grafana/plugins-cdn-tools#463. Renovate PRs get permanently stuck when a runner eviction cancels one of their checks: the cancelled check never reruns on its own, the Renovate approve workflow fails its wait step, and nothing fires a new pull_request event to retry either one (renovate only rebases on conflict).

This adds a sweep, hourly during Mon-Thu working hours to match the renovate schedule in grafana/grafana-catalog-team#1065, that finds open renovate PRs with infra-cancelled runs, reruns those runs, and reruns the failed Renovate approve run so it can wait on the fresh attempt and approve. Genuine CI failures are left alone: the sweep only acts when a cancelled run exists, and gives up after 3 attempts per run.