### PR TITLE
chore(renovate): drop repo schedule in favor of team preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,6 @@
     "github>grafana/grafana-renovate-config//presets/labels",
     "github>grafana/grafana-renovate-config//presets/npm"
   ],
-  "schedule": [
-    "before 6am on the first day of the week"
-  ],
   "extends": [
     "github>grafana/grafana-catalog-team//renovate/renovate"
   ],


### PR DESCRIPTION
Removes the repo-level Monday-early-morning schedule so the team preset's Mon-Thu working hours schedule applies (grafana/grafana-catalog-team#1065). A repo-level schedule overrides the preset value, and merging renovate PRs at 6am Monday defeats the point of keeping auto-merges inside hours where someone can catch a bad one.