### PR TITLE
chore(renovate): drop redundant rules, judge majors individually, automerge lockfile PRs

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -54,7 +54,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "Automated approval: patch, pin, digest or dev dependency update with all CI checks green."
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "Automated approval: patch, pin, digest or lock file maintenance update with all CI checks green."
 
       - name: Checkout
         if: contains(github.event.pull_request.labels.*.name, 'claude-gate')

--- a/renovate.json
+++ b/renovate.json
@@ -11,26 +11,13 @@
   ],
   "packageRules": [
     {
+      "description": "Runtime @grafana packages are provided by Grafana itself, bumping them raises the effective minimum Grafana version and must happen deliberately together with grafanaDependency",
       "groupName": "Grafana packages",
       "matchPackageNames": [
         "/^@grafana//"
       ],
       "matchDepTypes": [
         "dependencies"
-      ],
-      "enabled": false
-    },
-    {
-      "groupName": "React and React DOM",
-      "matchPackageNames": [
-        "/^react$/",
-        "/^@types/react/",
-        "/^react-dom$/",
-        "/^@types/react-dom/",
-        "/^react-router-dom$/"
-      ],
-      "matchUpdateTypes": [
-        "major"
       ],
       "enabled": false
     },
@@ -44,47 +31,6 @@
         "patch",
         "pin",
         "digest"
-      ]
-    },
-    {
-      "groupName": "Testing tools",
-      "matchPackageNames": [
-        "/^jest$/",
-        "/^jest-/",
-        "/^@jest//",
-        "/^@testing-library//",
-        "/^@playwright//",
-        "/^playwright$/",
-        "/^@types/jest/",
-        "/^@types/testing-library/"
-      ]
-    },
-    {
-      "groupName": "Build tools",
-      "matchPackageNames": [
-        "/^webpack$/",
-        "/^webpack-/",
-        "/-webpack-plugin$/",
-        "/-loader$/",
-        "/^@swc//",
-        "/^swc-/",
-        "/^terser-/",
-        "/^copy-webpack-plugin$/",
-        "/^fork-ts-checker-webpack-plugin$/",
-        "/^replace-in-file-webpack-plugin$/",
-        "/^ts-node$/"
-      ]
-    },
-    {
-      "groupName": "TypeScript and linting",
-      "matchPackageNames": [
-        "/^typescript$/",
-        "/^@typescript-eslint//",
-        "/^eslint$/",
-        "/^eslint-/",
-        "/^@stylistic//",
-        "/^prettier$/",
-        "/^@types/eslint/"
       ]
     },
     {
@@ -103,17 +49,8 @@
       "matchUpdateTypes": [
         "patch",
         "pin",
-        "digest"
-      ],
-      "automerge": true,
-      "addLabels": [
-        "automerge-direct"
-      ]
-    },
-    {
-      "description": "Automerge pilot: dev dependencies get a direct bot approval, required CI checks still gate the merge",
-      "matchDepTypes": [
-        "devDependencies"
+        "digest",
+        "lockFileMaintenance"
       ],
       "automerge": true,
       "addLabels": [


### PR DESCRIPTION
Slims the renovate config down to what actually does something:

- The React major block duplicated the team preset's allowedVersions caps (react ^18, react-router-dom <7), removed.
- The thematic groups (Testing tools, Build tools, TypeScript and linting) made grouped majors merge all-or-nothing. The eslint 10 bump blocked the whole TypeScript group for three weeks (#348, #355) until the preset capped it. Majors now get individual PRs, each judged by the Claude gate. Lockstep families stay grouped via group:monorepos in the team preset (grafana/grafana-catalog-team#1088).
- The devDependencies rule was a no-op: patch/pin/digest devDeps already got automerge-direct, and minor/major devDeps carried both labels with claude-gate taking precedence in the workflow. Removed, so devDep minors/majors are explicitly Claude-gated like everything else.
- Lock file maintenance PRs were the only renovate PRs still merged by hand (thanks Andres), they now get automerge-direct.

The @grafana runtime deps rule and the non-major batch group stay, with a description added to the former explaining why it exists.