### PR TITLE
ci: trigger renovate approve on labeled events

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -2,7 +2,11 @@ name: Renovate approve
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # labeled: renovate adds the tier labels right after creating the PR, so
+    # the opened event payload can miss them and every label-gated step skips.
+    # Each label event cancels the previous run via the concurrency group and
+    # the last one carries the full label set.
+    types: [opened, synchronize, reopened, labeled]
 
 permissions: {}
 


### PR DESCRIPTION
Renovate creates the PR first and adds the tier labels a second later, so the `opened` event payload can miss them. When that race is lost, every label-gated step in the approve workflow skips, the run still reports success, and nothing retries it. That stranded grafana/extensionsdependencygraph-app#85 without a gate review.

Adding `labeled` to the trigger types fixes it: each label event cancels the previous run through the existing concurrency group, and the last one carries the full label set.