### PR TITLE
fix: resolve react-router-dom v7 peer dependency conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
-        "@grafana/assistant": "0.1.24",
+        "@grafana/assistant": "0.1.29",
         "@grafana/data": "13.1.0-27110140411",
         "@grafana/i18n": "13.1.0-27110140411",
         "@grafana/llm": "0.22.1",
@@ -22,7 +22,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-markdown": "10.1.0",
-        "react-router-dom": "6.30.4",
+        "react-router-dom": "7.0.0",
         "react-use": "17.6.1",
         "rxjs": "7.8.2"
       },
@@ -1510,14 +1510,17 @@
       }
     },
     "node_modules/@grafana/assistant": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@grafana/assistant/-/assistant-0.1.24.tgz",
-      "integrity": "sha512-KX4NHsDLFeH1U6uYYKQzceBwAWUaAggmlZGZ+Lp5ZbnC+cW76+8c988ysdOYm3zix4oMEAbzghaJit15VRZYDg==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@grafana/assistant/-/assistant-0.1.29.tgz",
+      "integrity": "sha512-maNS6ID07MTNve/0sSh3IxSgHdBgo8JcoW8BgEijqLAtvUqLF8YusCo5JZ5OPAS0N2RzawT4SFAPBiQO8yK8EQ==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
       "peerDependencies": {
+        "@emotion/css": ">=11.0.0",
         "@grafana/data": ">=12.1.0",
         "@grafana/runtime": ">=12.1.0",
-        "@grafana/scenes": ">=5.41.0",
         "@grafana/schema": ">=12.1.0",
         "@grafana/ui": ">=12.1.0",
         "react": ">=18.0.0",
@@ -1603,31 +1606,6 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
-      }
-    },
-    "node_modules/@grafana/e2e-selectors": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0.tgz",
-      "integrity": "sha512-g/N5gGZ4iE59g4Coi/R6+F66BRrBnP0XKa7DO7sbiGo4IgM2tGsXgVvWNcR4CCF7bza930mhVWQnREyNLhClFw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "semver": "^7.7.0",
-        "typescript": "6.0.2"
-      }
-    },
-    "node_modules/@grafana/e2e-selectors/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@grafana/eslint-config": {
@@ -1851,39 +1829,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/@grafana/scenes": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@grafana/scenes/-/scenes-8.10.2.tgz",
-      "integrity": "sha512-jAJp3Krzd3A6HIKrs9rQkpB3kHmendmGrjb85fQ4PBTMq8gVuyBzkVHmBRa3MgAsgwTvfq1HBX14MKNU06gXbQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@floating-ui/react": "^0.27.0",
-        "@leeoniya/ufuzzy": "^1.0.16",
-        "@tanstack/react-virtual": "^3.9.0",
-        "history": "^4.9.0",
-        "lodash": "^4.17.21",
-        "react-grid-layout": "^1.3.4",
-        "react-select": "^5.10.2",
-        "react-use": "^17.5.0",
-        "react-virtualized-auto-sizer": "^1.0.24",
-        "uuid": "^11.0.0"
-      },
-      "peerDependencies": {
-        "@grafana/data": ">=11.6",
-        "@grafana/e2e-selectors": ">=11.6",
-        "@grafana/i18n": "*",
-        "@grafana/runtime": ">=11.6",
-        "@grafana/schema": ">=11.6",
-        "@grafana/ui": ">=11.6",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "react-router-dom": "^6.28.0",
-        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@grafana/schema": {
@@ -4995,6 +4940,12 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
@@ -9294,13 +9245,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-equals": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
-      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
@@ -12501,6 +12445,19 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -14997,21 +14954,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-draggable": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.7.0.tgz",
-      "integrity": "sha512-kTpANmKWVnFXiZ76Ag2ZowiFStuBYnJ606PI1TbUsOg29/400/JNIxI9+CuenhiAqFuXWJffz6F4UI3R51kUug==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
-      }
-    },
     "node_modules/react-dropzone": {
       "version": "14.3.8",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
@@ -15036,25 +14978,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "16.8 - 19"
-      }
-    },
-    "node_modules/react-grid-layout": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.3.tgz",
-      "integrity": "sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "clsx": "^2.1.1",
-        "fast-equals": "^4.0.3",
-        "prop-types": "^15.8.1",
-        "react-draggable": "^4.4.6",
-        "react-resizable": "^3.0.5",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-highlight-words": {
@@ -15217,21 +15140,6 @@
         }
       }
     },
-    "node_modules/react-resizable": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
-      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prop-types": "15.x",
-        "react-draggable": "^4.5.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3",
-        "react-dom": ">= 16.3"
-      }
-    },
     "node_modules/react-router": {
       "version": "6.30.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
@@ -15248,20 +15156,56 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.0.tgz",
+      "integrity": "sha512-2QAxXpwgQuh423C64oZiV2cCKPCNUgZxcvZaS8O0PAHPZ/z8kTq7YbGD4KTNZm6Yj66d+HAfGkWPp8MCpdtD+Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.0.tgz",
+      "integrity": "sha512-1xf+yMVhUjAzZGY90ZnYJ9KVe1R8FggpugzRBkh+p6vl4cC1sHDe3nO+r5rxWTAgCMf8uN5hfoV2M7rLVTWPUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-select": {
@@ -15370,17 +15314,6 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
-      }
-    },
-    "node_modules/react-virtualized-auto-sizer": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
-      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-window": {
@@ -16010,6 +15943,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -17321,6 +17260,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -17388,6 +17333,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@emotion/css": "11.13.5",
-    "@grafana/assistant": "0.1.24",
+    "@grafana/assistant": "0.1.29",
     "@grafana/data": "13.1.0-27110140411",
     "@grafana/i18n": "13.1.0-27110140411",
     "@grafana/llm": "0.22.1",

--- a/src/components/App/App.test.tsx
+++ b/src/components/App/App.test.tsx
@@ -26,7 +26,7 @@ describe('Components/App', () => {
 
   test('renders without an error"', async () => {
     render(
-      <BrowserRouter basename="/" future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <BrowserRouter basename="/">
         <App {...props} />
       </BrowserRouter>
     );

--- a/src/components/CheckDrillDown/IssueDescription.test.tsx
+++ b/src/components/CheckDrillDown/IssueDescription.test.tsx
@@ -30,9 +30,7 @@ const defaultProps = {
 };
 
 const renderWithRouter = (component: React.ReactElement) => {
-  return render(
-    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>{component}</BrowserRouter>
-  );
+  return render(<BrowserRouter>{component}</BrowserRouter>);
 };
 
 describe('IssueDescription', () => {

--- a/src/components/test/utils.tsx
+++ b/src/components/test/utils.tsx
@@ -8,7 +8,7 @@ export const renderWithRouter = (ui: React.ReactElement, { route = '/' } = {}) =
   return waitFor(() =>
     render(
       <ContextProvider>
-        <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }} initialEntries={[route]}>
+        <MemoryRouter initialEntries={[route]}>
           {ui}
         </MemoryRouter>
       </ContextProvider>


### PR DESCRIPTION
## Summary
Fixes the failing CI on #376 (react-router-dom v7 bump).

- `@grafana/scenes@8.13.3` is a required peer dependency of `@grafana/assistant@0.1.24`, and still pins `react-router-dom@^6.28.0`. That made `npm ci` fail with `ERESOLVE` once react-router-dom was bumped to 7.0.0 (and is why Renovate's own artifact-update step also failed).
- Bumped `@grafana/assistant` 0.1.24 → 0.1.29, which drops the `@grafana/scenes` peer dependency entirely, resolving the conflict without needing `overrides` or `--legacy-peer-deps`.
- Regenerated `package-lock.json`.
- Removed the `future={{ v7_startTransition, v7_relativeSplatPath }}` props from `BrowserRouter`/`MemoryRouter` in test files — those flags were removed in v7 since the behavior is now the default (this was a `tsc` type error).

## Test plan
- [x] `npm ci` succeeds cleanly (no ERESOLVE)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test:ci` passes (125 tests)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)