### PR TITLE
chore(ci): send CD Slack notifications to #grafana-catalog-ci

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
 
       # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
-      argo-workflow-slack-channel: '#grafana-plugins-platform-ci'
+      argo-workflow-slack-channel: '#grafana-catalog-ci'
 
       # Other CI inputs
       run-playwright: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -29,7 +29,7 @@ jobs:
 
       # Argo CD inputs
       grafana-cloud-deployment-type: provisioned
-      argo-workflow-slack-channel: '#grafana-plugins-platform-ci'
+      argo-workflow-slack-channel: '#grafana-catalog-ci'
       # Silence notifications when deploying from main branch to dev
       argo-workflow-slack-silent: true
       auto-merge-environments: dev


### PR DESCRIPTION
The team CI channel moved from #grafana-plugins-platform-ci to #grafana-catalog-ci. Updates the publish and push workflows.