### PR TITLE
ci(renovate-approve): label needs-human verdicts for filtering

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -270,10 +270,21 @@ jobs:
                 body="${verdict#VERDICT: approve}"
                 gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "${body# }"
               fi
+              # A rebase can turn an earlier needs-human into an approve; drop
+              # the stale label so the filter only shows PRs still waiting.
+              gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label needs-manual-review 2>/dev/null || true
               ;;
             "VERDICT: needs-human"*)
               body="${verdict#VERDICT: needs-human}"
               gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
                 --body "$(printf 'Needs human review: %s\n\n<!-- renovate-approve: judged %s -->' "${body# }" "$HEAD_SHA")"
+              # Label for filtering (e.g. org-wide `gh search prs --label needs-manual-review`).
+              # Best-effort: a label failure must not fail the gate, the comment
+              # above is what marks the commit as judged.
+              gh label create needs-manual-review --repo "$GITHUB_REPOSITORY" --force \
+                --description "Renovate gate: Claude declined to auto-approve, a human must decide" \
+                --color D93F0B 2>/dev/null || true
+              gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label needs-manual-review ||
+                echo "Could not add the needs-manual-review label; continuing."
               ;;
           esac


### PR DESCRIPTION
Same change as grafana/plugin-actions#298: when the gate ends in a needs-human verdict, the PR also gets a `needs-manual-review` label so these PRs can be filtered across repos (`gh search prs --owner grafana --label needs-manual-review --state open`). An approve verdict after a rebase removes the label again. Label handling is best-effort and never fails the gate.

Part of grafana/grafana-catalog-team#1052.