### PR TITLE
Add tracking for Advisor language usage

### DIFF
--- a/src/api/useInteractionTracker.test.ts
+++ b/src/api/useInteractionTracker.test.ts
@@ -1,15 +1,26 @@
 import { renderHook } from '@testing-library/react';
 import { useInteractionTracker, CheckInteractionType, GlobalActionType } from './useInteractionTracker';
-import { usePluginInteractionReporter } from '@grafana/runtime';
+import { config, usePluginInteractionReporter } from '@grafana/runtime';
 
 // Mock @grafana/runtime
 jest.mock('@grafana/runtime', () => ({
   usePluginInteractionReporter: jest.fn(),
+  config: {
+    bootData: {
+      user: {
+        language: 'en-US',
+      },
+    },
+  },
 }));
 
 const mockUsePluginInteractionReporter = usePluginInteractionReporter as jest.MockedFunction<
   typeof usePluginInteractionReporter
 >;
+
+const setUserLanguage = (language: string) => {
+  config.bootData.user.language = language;
+};
 
 describe('useInteractionTracker', () => {
   let mockReport: jest.Mock;
@@ -21,6 +32,44 @@ describe('useInteractionTracker', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('trackAppTranslated', () => {
+    it('should track app view with a non-English language flagged as not default', () => {
+      setUserLanguage('es-ES');
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackAppTranslated();
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_app_translated', {
+        language: 'es-ES',
+        is_default_language: false,
+      });
+    });
+
+    it('should flag English as the default language', () => {
+      setUserLanguage('en-US');
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackAppTranslated();
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_app_translated', {
+        language: 'en-US',
+        is_default_language: true,
+      });
+    });
+
+    it('should label an unset language as the default', () => {
+      setUserLanguage('');
+      const { result } = renderHook(() => useInteractionTracker());
+
+      result.current.trackAppTranslated();
+
+      expect(mockReport).toHaveBeenCalledWith('grafana_plugin_advisor_app_translated', {
+        language: 'default',
+        is_default_language: true,
+      });
+    });
   });
 
   describe('trackGroupToggle', () => {

--- a/src/api/useInteractionTracker.ts
+++ b/src/api/useInteractionTracker.ts
@@ -1,4 +1,4 @@
-import { usePluginInteractionReporter } from '@grafana/runtime';
+import { config, usePluginInteractionReporter } from '@grafana/runtime';
 import { useCallback } from 'react';
 
 // Enums for interaction types
@@ -28,6 +28,17 @@ function normalizeEventName(name: string): string {
 // Custom hook for tracking user interactions
 export function useInteractionTracker() {
   const report = usePluginInteractionReporter();
+
+  // App view tracking — fired once when the Advisor page is opened. Reports the
+  // user's configured language so we can measure how many people use Advisor in
+  // a language other than English.
+  const trackAppTranslated = useCallback(() => {
+    const language = config.bootData.user.language;
+    report('grafana_plugin_advisor_app_translated', {
+      language: language || 'default',
+      is_default_language: !language || language.startsWith('en'),
+    });
+  }, [report]);
 
   // Group toggle tracking
   const trackGroupToggle = useCallback(
@@ -71,6 +82,7 @@ export function useInteractionTracker() {
   );
 
   return {
+    trackAppTranslated,
     trackGroupToggle,
     trackCheckInteraction,
     trackGlobalAction,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { css } from '@emotion/css';
 import { Alert, EmptyState, Icon, LoadingPlaceholder, Stack, useStyles2 } from '@grafana/ui';
 import { isFetchError, PluginPage } from '@grafana/runtime';
@@ -11,9 +11,17 @@ import { useCheckSummaries, useCompletedChecks, useRetryCheck } from 'api/api';
 import { formatDate } from 'utils';
 import { InfoNotification } from 'components/InfoNotification/InfoNotification';
 import { NoChecksEmptyState } from 'components/NoChecksEmptyState';
+import { useInteractionTracker } from 'api/useInteractionTracker';
 
 export default function Home() {
   const styles = useStyles2(getStyles);
+  const { trackAppTranslated } = useInteractionTracker();
+
+  // Track a single app-view event per page open, capturing the UI language.
+  useEffect(() => {
+    trackAppTranslated();
+  }, [trackAppTranslated]);
+
   const {
     summaries,
     isLoading,


### PR DESCRIPTION
What

Add new event `grafana_plugin_advisor_app_translated`. It is fired when user open Advisor page. With this we can see how many users use Advisor in language different than English.

Event has:
- language — user language (like en-US, es-ES, de-DE)
- is_default_language — true when English, false when other language

Why

We added translations for Advisor in #280. Now we want to know how many people really use it in other language, so we can decide about next translations.

How

- Add trackAppTranslated() to existing useInteractionTracker hook (same way like other events).
- Language is taken from config.bootData.user.language.
- Event is sent one time on mount in Home.tsx.
- Add unit tests for English, non-English and empty language.

Fixes https://github.com/grafana/grafana-catalog-team/issues/1108